### PR TITLE
Rm explicit std dependency

### DIFF
--- a/bytes-extended/Forc.lock
+++ b/bytes-extended/Forc.lock
@@ -5,9 +5,9 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-7952FB133DF065C2'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?branch=master#a036dc5a5b6c604f6374b040559ededd4161240e'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
 dependencies = ['core']

--- a/bytes-extended/Forc.toml
+++ b/bytes-extended/Forc.toml
@@ -5,4 +5,3 @@ license = "Apache-2.0"
 name = "bytes_extended"
 
 [dependencies]
-std = { git = 'https://github.com/fuellabs/sway', branch = "master" }

--- a/hyperlane-mailbox/Forc.lock
+++ b/hyperlane-mailbox/Forc.lock
@@ -1,15 +1,11 @@
 [[package]]
 name = 'bytes_extended'
 source = 'path+from-root-D26B060B9C691B9B'
-dependencies = ['std git+https://github.com/fuellabs/sway?branch=master#22a150537a464a9297dd3f2664b5ca4ad303c677']
+dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-0076623D65EB340A'
-
-[[package]]
-name = 'core'
-source = 'path+from-root-A5A9AFB187495FC2'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'hyperlane-mailbox'
@@ -17,7 +13,7 @@ source = 'member'
 dependencies = [
     'hyperlane_message',
     'merkle',
-    'std git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8',
+    'std',
 ]
 
 [[package]]
@@ -25,20 +21,15 @@ name = 'hyperlane_message'
 source = 'path+from-root-D26B060B9C691B9B'
 dependencies = [
     'bytes_extended',
-    'std git+https://github.com/fuellabs/sway?branch=master#22a150537a464a9297dd3f2664b5ca4ad303c677',
+    'std',
 ]
 
 [[package]]
 name = 'merkle'
 source = 'path+from-root-D26B060B9C691B9B'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8']
+dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?branch=master#22a150537a464a9297dd3f2664b5ca4ad303c677'
-dependencies = ['core path+from-root-0076623D65EB340A']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8'
-dependencies = ['core path+from-root-A5A9AFB187495FC2']
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
+dependencies = ['core']

--- a/hyperlane-message-test/Forc.lock
+++ b/hyperlane-message-test/Forc.lock
@@ -1,22 +1,18 @@
 [[package]]
 name = 'bytes_extended'
 source = 'path+from-root-6CA64B415D07732F'
-dependencies = ['std git+https://github.com/fuellabs/sway?branch=master#a036dc5a5b6c604f6374b040559ededd4161240e']
+dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-7952FB133DF065C2'
-
-[[package]]
-name = 'core'
-source = 'path+from-root-A5A9AFB187495FC2'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'hyperlane-message-test'
 source = 'member'
 dependencies = [
     'hyperlane_message',
-    'std git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8',
+    'std',
 ]
 
 [[package]]
@@ -24,15 +20,10 @@ name = 'hyperlane_message'
 source = 'path+from-root-6CA64B415D07732F'
 dependencies = [
     'bytes_extended',
-    'std git+https://github.com/fuellabs/sway?branch=master#a036dc5a5b6c604f6374b040559ededd4161240e',
+    'std',
 ]
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?branch=master#a036dc5a5b6c604f6374b040559ededd4161240e'
-dependencies = ['core path+from-root-7952FB133DF065C2']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8'
-dependencies = ['core path+from-root-A5A9AFB187495FC2']
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
+dependencies = ['core']

--- a/hyperlane-message/Forc.lock
+++ b/hyperlane-message/Forc.lock
@@ -5,7 +5,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-0076623D65EB340A'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'hyperlane_message'
@@ -17,5 +17,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?branch=master#22a150537a464a9297dd3f2664b5ca4ad303c677'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
 dependencies = ['core']

--- a/hyperlane-message/Forc.toml
+++ b/hyperlane-message/Forc.toml
@@ -6,4 +6,3 @@ name = "hyperlane_message"
 
 [dependencies]
 bytes_extended = { path = "../bytes-extended" }
-std = { git = 'https://github.com/fuellabs/sway', branch = "master" }

--- a/merkle-test/Forc.lock
+++ b/merkle-test/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-A5A9AFB187495FC2'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'merkle'
@@ -17,5 +17,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
 dependencies = ['core']

--- a/merkle/Forc.lock
+++ b/merkle/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-A5A9AFB187495FC2'
+source = 'path+from-root-211041F05ED22121'
 
 [[package]]
 name = 'merkle'
@@ -9,5 +9,5 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.31.3#12ad8423811d566972dd75fbb954cdb95afde8d8'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
 dependencies = ['core']


### PR DESCRIPTION
Sway / forc 0.32.1 was shipped recently which includes the `Bytes` type. See https://github.com/FuelLabs/sway/tags

This removes the explicit std dependency. Just run `fuelup update` to get the newest version of forc