### PR TITLE
Don't copy / allocate new bytes in read_bytes

### DIFF
--- a/bytes-extended/Forc.lock
+++ b/bytes-extended/Forc.lock
@@ -5,9 +5,9 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-211041F05ED22121'
+source = 'path+from-root-E6BBD1A08F478960'
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.2#b9996f13463c324e256014935c053c334b880ab5'
 dependencies = ['core']

--- a/bytes-extended/src/main.sw
+++ b/bytes-extended/src/main.sw
@@ -279,6 +279,8 @@ impl Bytes {
 
     /// Reads Bytes starting at the specified offset with the `len` number of bytes.
     /// Does not copy any bytes, and instead points to the bytes within self.
+    /// Changing the contents of the returned bytes will affect self, so be cautious
+    /// of unintented consequences!
     /// Reverts if it violates the bounds of self.
     pub fn read_bytes(self, offset: u64, len: u64) -> Bytes {
         let read_ptr = self.get_read_ptr(

--- a/bytes-extended/src/main.sw
+++ b/bytes-extended/src/main.sw
@@ -278,15 +278,22 @@ impl Bytes {
     }
 
     /// Reads Bytes starting at the specified offset with the `len` number of bytes.
+    /// Does not copy any bytes, and instead points to the bytes within self.
     /// Reverts if it violates the bounds of self.
-    pub fn read_bytes(ref mut self, offset: u64, len: u64) -> Bytes {
+    pub fn read_bytes(self, offset: u64, len: u64) -> Bytes {
         let read_ptr = self.get_read_ptr(
             offset,
             len,
         );
 
-        let mut bytes = Bytes::with_length(len);
-        bytes.write_packed_bytes(0u64, read_ptr, len);
+        // Create an empty Bytes
+        let mut bytes = Bytes::new();
+        // Manually set the RawBytes ptr to where we want to read from.
+        bytes.buf.ptr = read_ptr;
+        // Manually set the RawBytes cap to the number of bytes.
+        bytes.buf.cap = len;
+        // Manually set the len to the correct number of bytes.
+        bytes.len = len;
         bytes
     }
 

--- a/hyperlane-message-test/Forc.lock
+++ b/hyperlane-message-test/Forc.lock
@@ -5,7 +5,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-211041F05ED22121'
+source = 'path+from-root-E6BBD1A08F478960'
 
 [[package]]
 name = 'hyperlane-message-test'
@@ -25,5 +25,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.2#b9996f13463c324e256014935c053c334b880ab5'
 dependencies = ['core']

--- a/hyperlane-message/Forc.lock
+++ b/hyperlane-message/Forc.lock
@@ -5,7 +5,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-211041F05ED22121'
+source = 'path+from-root-E6BBD1A08F478960'
 
 [[package]]
 name = 'hyperlane_message'
@@ -17,5 +17,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.32.1#50c1b6c858c044acf88760cb7eb1b39d076f322d'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.32.2#b9996f13463c324e256014935c053c334b880ab5'
 dependencies = ['core']


### PR DESCRIPTION
Fixes #25 

* Creates a new Bytes instance that points to the existing point in memory
* Drive by - noticed that self was `ref mut` when it didn't need to be