### PR TITLE
Forc 0.35, fuels-rs 0.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,20 +1594,21 @@ dependencies = [
 
 [[package]]
 name = "fuel-abi-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71965918f5bab4fcc614a5c4b96de51f7164934face14b37fa98fa12985150fc"
+checksum = "47d99a7aeb41cdabffa38418b00fd57b5571dc58ee5af606e845a088befecd36"
 dependencies = [
  "lazy_static",
  "regex",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
 name = "fuel-asm"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df7be33ffb99e92e8c76a25de7d6460566822420ee86e59d2214eec58e90a1d"
+checksum = "2848e936ce953d9571771279b270ee6f098c04ad5cbb7227bf5dc04abfc57b59"
 dependencies = [
  "fuel-types",
  "serde",
@@ -1615,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a12ab7c594735d62aef7a0e3d32b9f9cdfacbeabe41a3e342e57bfd9d578ee"
+checksum = "32fb0342994322413cddbc96262bb7d4a02fbe958b4d976d1e6dba2563964f5d"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1659,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7eb6f504bf9d090bea6e64d6777a7d996ccce5b620404002ce5d439dd03f298"
+checksum = "a2a2c61d86fbb39626a19cfa1768726133bcab2e579f55a230439dd96274dc2f"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -1679,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c614d966367774d4c3a55e0bb6d7c448584e077340bc1fb5a483f11ba7e5028d"
+checksum = "c266371cd8b50749f95e330712ee7393c9e8297c1bc3e648191b6b8f6d7ffa7f"
 dependencies = [
  "anyhow",
  "cynic",
@@ -1702,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eee45359b0726dbf3a1d6cafa20d110f1dca95757f2cbfd7c49af7964e0745"
+checksum = "d04d34ab3d655c1023d511c3289856289a1c02ec6afecee3f174020379307b4b"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -1715,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8c2ff93fff977ba97149ccbf6e358e9d55d51a568f3f23623b67afef4090da"
+checksum = "bcefad49931a35d613739c3bcfd8b4b8433ad75e63f23dbe2595da48bcbc400a"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -1727,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e5e2dffe9229df9a590e1bd8920b64ad35edee76dc3133f4c00913d8647df6"
+checksum = "304547fa8af9e0438cab61388fd9a727c6e06a9ace89f26c9f7d1e4b5e9b3efc"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -1739,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c32390855e34a5cd208bee695fb3fabf58e0e46ef3d84123b87684a5d23b5c4"
+checksum = "35db9567dfb0928133832e86b6bc38a3329fbfb2da8f00d4c09241de20efe700"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -1753,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba1818542dc1e8d8a6100f6b3b3c10ef12dc24dfb404066023ab1b54689f49c"
+checksum = "4713699e67a1026ba19b1875213752b42120fab7bc3afd06778932b35f18fa27"
 dependencies = [
  "axum",
  "lazy_static",
@@ -1765,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384f926cf74551b0d5c87f1910b7f7bb05c285fbb9c479105095d666fde72eb0"
+checksum = "4e9b9b4990ec484cd8c50b96cb69082c7790d1cde9f0e747428ae4f4e4c32a55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1782,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17c5ac690312e5d2befc400a936ef0297454d641c29658df816c3bca8692116"
+checksum = "4786940495411f0cdf46e5fb02ba0d96fd8dfc6e6fe21f4e6276881eaef48087"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1797,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e7d7a9aaa42e2fa6238ad1e57e34db784aaf0d54cb9f192efe54f53307675"
+checksum = "d4f2c8a493b2a99c5b4658f36830a69421494fbdb18fadb0413ed94c52525aaf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1811,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b56d7971aaf43a3981ab55a1c2ed145c61779936e9258e29637789e2771a1af"
+checksum = "9a1bcd22a75ad63837c37d93148e7d256a59476613d2741b544dea77911abd9b"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -1823,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c40dc1ee77c726b460bc318a73fb9fd478c0afa832b7e8872d6b03d774b6f23"
+checksum = "1b760fbd2bd20bd27698388e078f9cb061b043dad60f509504650ddaca0e4216"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1842,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f362368b0ba08aee81e4ac45d555c605467eacab3319ebcc00bbe62e1f25b36b"
+checksum = "2fc51933cce4d10ec8fa8fb6a2ed1b8edc11e30d9a33e58066b9221d5613e111"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -1858,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f09781cbc54fc422456e1bc0c7b3101d879d848cc13992aeae60d088cf1bbd"
+checksum = "efba8a3c2c91bdec93b5328b31f71167a42c23555a8885cb7d55ab66632d8fa1"
 dependencies = [
  "borrown",
  "coins-bip32",
@@ -1877,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54de90857ac30eee21c9bbc60e0e6701c0d21913418f6c8be88d0ea8d1cded9"
+checksum = "fe9d6caf8ad593cd8665e431aec18c1b4550db2e0f52d958547fca81c2c07077"
 dependencies = [
  "digest 0.10.6",
  "fuel-storage",
@@ -1891,15 +1892,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93354a7d1ba3de35a3073237eebf492df9c76a4bf4ccfc4af8ed76fee2b164f"
+checksum = "cc7969a1fab462d0ed9aadb9df98ff40c92b9d5b7e029de6e48d40a068e49e05"
 
 [[package]]
 name = "fuel-tx"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0da1d6c6886e670e0c37da53f7b73935712ea346d216d275d0e72b81c2eb982"
+checksum = "8e0bbf8d062f8a41395184b7d60c1bb674254545dd64a0026beda65005de8bc7"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -1915,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a893af21a88f56f912964c734d007c9d46224146e3e9877262a39e25135fa3"
+checksum = "9b8c43ba619e6259a74c9368109006937dfd62cc0b875c2ae13ae6ffa52264f2"
 dependencies = [
  "rand",
  "serde",
@@ -1925,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc26d8221b5d40f4ac24a6d566475416665443adae5b6a9cedc3712d7bc185"
+checksum = "87dbbf70e3be9243d5cb237e6e3ad2ef18fcad8c725f6c50e2451546e3f61636"
 dependencies = [
  "bitflags",
  "fuel-asm",
@@ -1947,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27f160a0f6c1ab5f62bf890db2e55182d5dc069370dcb26c5428154b6f84bcc"
+checksum = "0cb5af8cab660ba02d2e61bc16812fdd6e93f64a5c023d510d7fb615e400704c"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -1964,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f4dc5d3c341dc45798913c8d5334d13f05cc62b4cb7fb9c5e05c33cc160546"
+checksum = "e78cd0139231c728374e54cce8c2277ae1afddcee666547ce30c8a8d7f7b1f06"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1981,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954598e797e94f530af81ecb2bc5fcf93a1d787abd355823580f941f193c6b76"
+checksum = "37aa5dbcf0b1e08818ff8d9caac82e8da8e81748a83860e58979b46aa77b5d28"
 dependencies = [
  "fuel-tx",
  "fuel-types",
@@ -1996,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75383dfdb605a98c7d18a610a97d002c25157004d41387c67d9ae61d8d4d9bb2"
+checksum = "b04fcfb17385f702c9aa7958e57630c3fbdf0d86e34093ced9cc3a606c192962"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2015,11 +2016,12 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78a4ee25326c960a3b84e5e5136e537ad04007c2766366a08395f1292d9dd3d"
+checksum = "bacdabf09515dc95f3251d80ade1a876da951d988d48866c80940d594280a796"
 dependencies = [
  "bytes",
+ "fuel-abi-types",
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
@@ -2043,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f192607ddd1a138228a9984822c6b5b77841ce2427b6f04b91ccb96c8f297e8"
+checksum = "dee5a705cfb87a8fa51e28478597db38109701be82238534a4a18f34bc8e3d39"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2071,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11801199c43a37c39aec97d5963cad8660bd13ce72a4416cddb704d051fb537"
+checksum = "944433f739289f94e5a415684251211cfdb511849b58e2350c524a9b0d60f1c5"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",
@@ -2086,6 +2088,7 @@ dependencies = [
  "fuels-programs",
  "fuels-signers",
  "fuels-types",
+ "futures",
  "hex",
  "portpicker",
  "rand",
@@ -2099,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a522e7a3cbe922d80d15e1495aa74fa19aa7a8d6ece325f1701db7ac261ff820"
+checksum = "11c90a74c9ef4703d87e0085240fb1ef53cf0266174482ba137e00dafd6515e4"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
@@ -2132,9 +2135,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2147,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2157,15 +2160,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2174,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-locks"
@@ -2190,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2201,15 +2204,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -2219,9 +2222,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,14 +210,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "atomic-polyfill"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "critical-section",
 ]
 
 [[package]]
@@ -577,26 +586,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -607,12 +614,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "codespan-reporting"
@@ -782,6 +795,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crunchy"
@@ -1087,15 +1106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,17 +1113,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1219,6 +1218,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1573,185 +1593,101 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-asm"
-version = "0.10.0"
+name = "fuel-abi-types"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781568e982a90f25bfaf019196ca135fdf58a1826a8e68fbb1af2ad8b3c2a6fc"
+checksum = "71965918f5bab4fcc614a5c4b96de51f7164934face14b37fa98fa12985150fc"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "fuel-asm"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df7be33ffb99e92e8c76a25de7d6460566822420ee86e59d2214eec58e90a1d"
 dependencies = [
  "fuel-types",
  "serde",
 ]
 
 [[package]]
-name = "fuel-block-executor"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fda2b9586c6b3ad0d022c0faa62590ddc0cb957abc010724d7a6d828eb1fab"
-dependencies = [
- "anyhow",
- "fuel-chain-config",
- "fuel-core-interfaces",
- "tokio",
-]
-
-[[package]]
-name = "fuel-block-importer"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e51cd0d94392abebac24a458f61be1ab52cda63280642c3f6070e39f21c8ce6"
-dependencies = [
- "anyhow",
- "fuel-core-interfaces",
- "parking_lot 0.12.1",
- "tokio",
-]
-
-[[package]]
-name = "fuel-block-producer"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c37ba4ce09cbbd54382f0ddba0d556602ac66d7bd18d61c66f13281be2fbd4a"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-interfaces",
- "parking_lot 0.12.1",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fuel-chain-config"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe82b229c14d2a57ba7b76f219dcc84b861ff3c7f7584db0a15e94dee293f87"
-dependencies = [
- "anyhow",
- "bincode",
- "fuel-core-interfaces",
- "fuel-poa-coordinator",
- "hex",
- "itertools",
- "rand",
- "serde",
- "serde_json",
- "serde_with",
- "tracing",
-]
-
-[[package]]
 name = "fuel-core"
-version = "0.15.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d61bdbb32c0dde8c745fc47b8ef162ac00e5390a876944aed8e177511779c"
+checksum = "46a12ab7c594735d62aef7a0e3d32b9f9cdfacbeabe41a3e342e57bfd9d578ee"
 dependencies = [
  "anyhow",
  "async-graphql",
  "async-trait",
  "axum",
- "bech32 0.9.1",
- "bincode",
- "byteorder",
  "clap",
  "derive_more",
- "dirs",
  "enum-iterator",
- "fuel-block-executor",
- "fuel-block-importer",
- "fuel-block-producer",
- "fuel-chain-config",
- "fuel-core-bft",
- "fuel-core-interfaces",
- "fuel-poa-coordinator",
- "fuel-sync",
- "fuel-txpool",
+ "fuel-core-chain-config",
+ "fuel-core-consensus-module",
+ "fuel-core-database",
+ "fuel-core-executor",
+ "fuel-core-importer",
+ "fuel-core-poa",
+ "fuel-core-producer",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-txpool",
+ "fuel-core-types",
  "futures",
  "hex",
+ "hyper",
  "itertools",
- "lazy_static",
  "num_cpus",
+ "postcard",
  "primitive-types",
  "rand",
  "serde",
  "serde_json",
- "serde_with",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tower-http",
- "tower-layer",
  "tracing",
- "tracing-subscriber",
- "url",
  "uuid 1.2.2",
 ]
 
 [[package]]
-name = "fuel-core-bft"
-version = "0.15.1"
+name = "fuel-core-chain-config"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e55b4064ab480bc88979b312c0997238234408c953b0709d19ec0b5694b6c50"
+checksum = "c7eb6f504bf9d090bea6e64d6777a7d996ccce5b620404002ce5d439dd03f298"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces",
- "parking_lot 0.12.1",
- "tokio",
-]
-
-[[package]]
-name = "fuel-core-interfaces"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9894595fb37132a517f7df87dae2926bc5bfc5bc1466f3e287527e7b2d129bd4"
-dependencies = [
- "anyhow",
- "async-trait",
- "derive_more",
- "fuel-vm",
- "lazy_static",
- "parking_lot 0.12.1",
- "secrecy",
- "serde",
- "tai64",
- "thiserror",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "fuel-crypto"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365c114728301916a58c932c304feb8836c51f65e0153a3f2157bf6cbb4c32ef"
-dependencies = [
- "borrown",
- "coins-bip32",
- "coins-bip39",
- "fuel-types",
- "lazy_static",
+ "bech32 0.9.1",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "hex",
+ "itertools",
+ "postcard",
  "rand",
- "secp256k1",
  "serde",
- "sha2 0.10.6",
- "zeroize",
+ "serde_json",
+ "serde_with",
+ "tracing",
 ]
 
 [[package]]
-name = "fuel-gql-client"
-version = "0.15.1"
+name = "fuel-core-client"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2c6a001f6944fddbf488d53edaa7d7c5f8b380f18a69c322380d3d01741885"
+checksum = "c614d966367774d4c3a55e0bb6d7c448584e077340bc1fb5a483f11ba7e5028d"
 dependencies = [
  "anyhow",
- "clap",
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-vm",
+ "fuel-core-types",
  "futures",
  "hex",
  "hyper-rustls 0.22.1",
@@ -1761,27 +1697,65 @@ dependencies = [
  "serde_json",
  "tai64",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
-name = "fuel-merkle"
-version = "0.4.1"
+name = "fuel-core-consensus-module"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e56cc8be0a2ea7cfb30ae4696bf5f658a9447df1b32af699b6273a11fdcfa3"
+checksum = "18eee45359b0726dbf3a1d6cafa20d110f1dca95757f2cbfd7c49af7964e0745"
 dependencies = [
- "digest 0.10.6",
- "fuel-storage",
- "hashbrown",
- "hex",
- "sha2 0.10.6",
+ "anyhow",
+ "fuel-core-chain-config",
+ "fuel-core-poa",
+ "fuel-core-types",
+ "tokio",
+]
+
+[[package]]
+name = "fuel-core-database"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8c2ff93fff977ba97149ccbf6e358e9d55d51a568f3f23623b67afef4090da"
+dependencies = [
+ "anyhow",
+ "fuel-core-storage",
+ "fuel-core-types",
  "thiserror",
 ]
 
 [[package]]
-name = "fuel-metrics"
-version = "0.15.1"
+name = "fuel-core-executor"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb400bda055e39d7c2ed7405ff1088f7dce0c0eea0bfce4b9bed3bda84da2d8"
+checksum = "67e5e2dffe9229df9a590e1bd8920b64ad35edee76dc3133f4c00913d8647df6"
+dependencies = [
+ "anyhow",
+ "fuel-core-chain-config",
+ "fuel-core-storage",
+ "fuel-core-types",
+]
+
+[[package]]
+name = "fuel-core-importer"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c32390855e34a5cd208bee695fb3fabf58e0e46ef3d84123b87684a5d23b5c4"
+dependencies = [
+ "anyhow",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-metrics"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba1818542dc1e8d8a6100f6b3b3c10ef12dc24dfb404066023ab1b54689f49c"
 dependencies = [
  "axum",
  "lazy_static",
@@ -1790,46 +1764,143 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-poa-coordinator"
-version = "0.15.1"
+name = "fuel-core-poa"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683746f58abe91007e507a2621860a21ac72cfeb22bf4e23d58689967dfdacca"
+checksum = "384f926cf74551b0d5c87f1910b7f7bb05c285fbb9c479105095d666fde72eb0"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-interfaces",
- "humantime-serde",
- "parking_lot 0.12.1",
- "serde",
+ "fuel-core-chain-config",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-producer"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17c5ac690312e5d2befc400a936ef0297454d641c29658df816c3bca8692116"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "fuel-storage"
-version = "0.3.0"
+name = "fuel-core-services"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f895423d18472d60eb078cf949608ff3fe6e42e91d41b85993b11528d2c4c3"
-
-[[package]]
-name = "fuel-sync"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279484394259877d3d742b9fc69271a05e2c203e3480ebbb67adf7aa964dedf1"
+checksum = "b12e7d7a9aaa42e2fa6238ad1e57e34db784aaf0d54cb9f192efe54f53307675"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces",
+ "async-trait",
+ "futures",
  "parking_lot 0.12.1",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
-name = "fuel-tx"
-version = "0.23.1"
+name = "fuel-core-storage"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffd148866f191397915b4a407455ece148197890ce5cf86d4b3f1eedcc7f35e"
+checksum = "8b56d7971aaf43a3981ab55a1c2ed145c61779936e9258e29637789e2771a1af"
 dependencies = [
- "bitflags",
+ "anyhow",
+ "fuel-core-types",
+ "fuel-vm",
+ "thiserror",
+]
+
+[[package]]
+name = "fuel-core-txpool"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c40dc1ee77c726b460bc318a73fb9fd478c0afa832b7e8872d6b03d774b6f23"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-chain-config",
+ "fuel-core-metrics",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-types",
+ "parking_lot 0.12.1",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-types"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f362368b0ba08aee81e4ac45d555c605467eacab3319ebcc00bbe62e1f25b36b"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "fuel-vm",
+ "secrecy",
+ "serde",
+ "tai64",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-crypto"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f09781cbc54fc422456e1bc0c7b3101d879d848cc13992aeae60d088cf1bbd"
+dependencies = [
+ "borrown",
+ "coins-bip32",
+ "coins-bip39",
+ "fuel-types",
+ "getrandom",
+ "lazy_static",
+ "rand",
+ "secp256k1",
+ "serde",
+ "sha2 0.10.6",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-merkle"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54de90857ac30eee21c9bbc60e0e6701c0d21913418f6c8be88d0ea8d1cded9"
+dependencies = [
+ "digest 0.10.6",
+ "fuel-storage",
+ "hashbrown 0.13.2",
+ "hex",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "fuel-storage"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93354a7d1ba3de35a3073237eebf492df9c76a4bf4ccfc4af8ed76fee2b164f"
+
+[[package]]
+name = "fuel-tx"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0da1d6c6886e670e0c37da53f7b73935712ea346d216d275d0e72b81c2eb982"
+dependencies = [
  "derivative",
  "fuel-asm",
  "fuel-crypto",
@@ -1843,27 +1914,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-txpool"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e316f4f81c6fbc75706b45962df6a35fe1bc8346f39639078dc3db1d68eb835f"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-chain-config",
- "fuel-core-interfaces",
- "fuel-metrics",
- "parking_lot 0.12.1",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "fuel-types"
-version = "0.5.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403dcac5f0788a8fbdb6cfa0e5690dd4fe4278648da674d7e430711abf90b570"
+checksum = "b6a893af21a88f56f912964c734d007c9d46224146e3e9877262a39e25135fa3"
 dependencies = [
  "rand",
  "serde",
@@ -1871,10 +1925,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.22.7"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6540c62a717f927704b44fd6fa0ea456a86c4e5732aadb191bb428f1b4937fda"
+checksum = "dfbc26d8221b5d40f4ac24a6d566475416665443adae5b6a9cedc3712d7bc185"
 dependencies = [
+ "bitflags",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle",
@@ -1892,44 +1947,82 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3110f3301c368eecb9c35fdc0c4ed7e8c9b73dc4b3855017bf6dd49a01656cc"
+checksum = "d27f160a0f6c1ab5f62bf890db2e55182d5dc069370dcb26c5428154b6f84bcc"
 dependencies = [
  "fuel-core",
- "fuel-gql-client",
- "fuels-abigen-macro",
- "fuels-contract",
+ "fuel-core-client",
+ "fuel-tx",
  "fuels-core",
+ "fuels-macros",
+ "fuels-programs",
  "fuels-signers",
  "fuels-test-helpers",
  "fuels-types",
 ]
 
 [[package]]
-name = "fuels-abigen-macro"
-version = "0.33.0"
+name = "fuels-code-gen"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eda4a42704c3e3c3e100d7604ac4a1a2dab26eb7bfd62031e6af93ce6f2a9ad"
+checksum = "c0f4dc5d3c341dc45798913c8d5334d13f05cc62b4cb7fb9c5e05c33cc160546"
 dependencies = [
  "Inflector",
- "fuels-core",
+ "fuel-abi-types",
+ "itertools",
+ "lazy_static",
  "proc-macro2",
  "quote",
- "rand",
+ "regex",
+ "serde_json",
  "syn",
 ]
 
 [[package]]
-name = "fuels-contract"
-version = "0.33.0"
+name = "fuels-core"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a8841208ab59958c0bac5118738cc3f6fa91d7bdef7751807344622008e803"
+checksum = "954598e797e94f530af81ecb2bc5fcf93a1d787abd355823580f941f193c6b76"
 dependencies = [
- "anyhow",
- "bytes",
- "fuel-gql-client",
  "fuel-tx",
+ "fuel-types",
+ "fuel-vm",
+ "fuels-types",
+ "hex",
+ "itertools",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "fuels-macros"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75383dfdb605a98c7d18a610a97d002c25157004d41387c67d9ae61d8d4d9bb2"
+dependencies = [
+ "Inflector",
+ "fuel-abi-types",
+ "fuels-code-gen",
+ "itertools",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "rand",
+ "regex",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "fuels-programs"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78a4ee25326c960a3b84e5e5136e537ad04007c2766366a08395f1292d9dd3d"
+dependencies = [
+ "bytes",
+ "fuel-tx",
+ "fuel-types",
+ "fuel-vm",
  "fuels-core",
  "fuels-signers",
  "fuels-types",
@@ -1937,7 +2030,6 @@ dependencies = [
  "hex",
  "itertools",
  "proc-macro2",
- "quote",
  "rand",
  "regex",
  "serde",
@@ -1950,46 +2042,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuels-core"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147fc4f999eb2367467b09390d991811ca8d951ccc704246f3ddcea9e413a435"
-dependencies = [
- "Inflector",
- "anyhow",
- "fuel-tx",
- "fuel-types",
- "fuels-types",
- "hex",
- "itertools",
- "lazy_static",
- "proc-macro2",
- "quote",
- "rand",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "strum 0.21.0",
- "strum_macros 0.21.1",
- "syn",
- "thiserror",
-]
-
-[[package]]
 name = "fuels-signers"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b2d832fbf4115a139981ad5a3823bc579505274faa1c74cdef1e90fc4a4b1d"
+checksum = "5f192607ddd1a138228a9984822c6b5b77841ce2427b6f04b91ccb96c8f297e8"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "elliptic-curve 0.11.12",
  "eth-keystore 0.3.0",
+ "fuel-core-client",
  "fuel-crypto",
- "fuel-gql-client",
+ "fuel-tx",
  "fuel-types",
+ "fuel-vm",
  "fuels-core",
  "fuels-types",
  "hex",
@@ -1997,24 +2064,26 @@ dependencies = [
  "rand",
  "serde",
  "sha2 0.9.9",
+ "tai64",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9567d6ede64654fa8edf3a3be22d0e8a2d672648aacb17476c5b3f5ca70ca1e6"
+checksum = "a11801199c43a37c39aec97d5963cad8660bd13ce72a4416cddb704d051fb537"
 dependencies = [
- "anyhow",
- "fuel-chain-config",
  "fuel-core",
- "fuel-core-interfaces",
- "fuel-gql-client",
+ "fuel-core-chain-config",
+ "fuel-core-client",
+ "fuel-core-types",
+ "fuel-tx",
  "fuel-types",
- "fuels-contract",
+ "fuel-vm",
  "fuels-core",
+ "fuels-programs",
  "fuels-signers",
  "fuels-types",
  "hex",
@@ -2030,16 +2099,18 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44b707a20ce7b4fd7cd3451e672552e9851fd9024422d68a875f6b12ab184e5"
+checksum = "a522e7a3cbe922d80d15e1495aa74fa19aa7a8d6ece325f1701db7ac261ff820"
 dependencies = [
- "anyhow",
  "bech32 0.9.1",
  "chrono",
- "fuel-chain-config",
- "fuel-gql-client",
+ "fuel-abi-types",
+ "fuel-core-chain-config",
+ "fuel-core-client",
  "fuel-tx",
+ "fuel-types",
+ "fuels-macros",
  "hex",
  "itertools",
  "lazy_static",
@@ -2252,12 +2323,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -2267,6 +2356,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.4",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2286,21 +2389,18 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -2369,22 +2469,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
 
 [[package]]
 name = "hyper"
@@ -2611,7 +2695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -2637,10 +2721,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2778,6 +2884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,15 +2913,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
 
 [[package]]
 name = "matchit"
@@ -2913,16 +3016,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
 ]
 
 [[package]]
@@ -3120,7 +3213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3128,12 +3221,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3386,6 +3473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
+dependencies = [
+ "cobs",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -3545,21 +3643,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
  "regex-syntax",
 ]
 
@@ -3806,6 +3895,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4210,15 +4313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4373,9 @@ name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -4289,6 +4386,12 @@ dependencies = [
  "base64ct",
  "der 0.6.1",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -4424,12 +4527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,15 +4544,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -4696,7 +4784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
@@ -4709,48 +4796,6 @@ dependencies = [
  "futures-task",
  "pin-project",
  "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -4893,12 +4938,6 @@ checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -5131,19 +5170,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5153,9 +5216,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5165,9 +5228,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5177,9 +5240,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5189,15 +5252,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5207,9 +5270,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb5af8cab660ba02d2e61bc16812fdd6e93f64a5c023d510d7fb615e400704c"
+checksum = "ec9f85950c301889c074c3882ccb49fca1900f0d54a434fede12ea55d4583e12"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -1965,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78cd0139231c728374e54cce8c2277ae1afddcee666547ce30c8a8d7f7b1f06"
+checksum = "7cfe362e48283fcb080c9f435fc1ac18aad34c3c3c91779cc99415862573faed"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa5dbcf0b1e08818ff8d9caac82e8da8e81748a83860e58979b46aa77b5d28"
+checksum = "d846794076498a56c4fdf64e62852a2e183f4a50a70492a329f54fce3830e95c"
 dependencies = [
  "fuel-tx",
  "fuel-types",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04fcfb17385f702c9aa7958e57630c3fbdf0d86e34093ced9cc3a606c192962"
+checksum = "ddb21e9d6e680e910e07aaa0b5570e54b93416d68d84dcf01c4df245168bef23"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacdabf09515dc95f3251d80ade1a876da951d988d48866c80940d594280a796"
+checksum = "6e736f3c2186876f4f7741f9c390b32d22c9819196470ec875fca6c1cacd74e0"
 dependencies = [
  "bytes",
  "fuel-abi-types",
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee5a705cfb87a8fa51e28478597db38109701be82238534a4a18f34bc8e3d39"
+checksum = "51eff88f45d0b813a9f44200d7bb14678a04c04e4d42f8cdd7e7b4e130ae4664"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2073,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944433f739289f94e5a415684251211cfdb511849b58e2350c524a9b0d60f1c5"
+checksum = "9b022b5daebc2c9e07bf35e6c7d71bc377859225c985fa900cca406b22a594eb"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",
@@ -2102,13 +2102,14 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c90a74c9ef4703d87e0085240fb1ef53cf0266174482ba137e00dafd6515e4"
+checksum = "5b3328fa28eac1bd6925a50a9d925a448141d48a1c3cac812defbcee159087f4"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
  "fuel-abi-types",
+ "fuel-asm",
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-tx",
@@ -2124,7 +2125,6 @@ dependencies = [
  "strum 0.21.0",
  "strum_macros 0.21.1",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eceaec3c8c5bc2c9cdbd29e9025d413d7fee87a0c5f9bc1d5f9d781cbd363bec"
+checksum = "b3110f3301c368eecb9c35fdc0c4ed7e8c9b73dc4b3855017bf6dd49a01656cc"
 dependencies = [
  "fuel-core",
  "fuel-gql-client",
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-abigen-macro"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077dbf9b23f87b7f61659da074d6e07a0d54ee44f05b0b56bb65beee07272e5f"
+checksum = "0eda4a42704c3e3c3e100d7604ac4a1a2dab26eb7bfd62031e6af93ce6f2a9ad"
 dependencies = [
  "Inflector",
  "fuels-core",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-contract"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1b27454217ad4bb99db6796d4239b12cf20959b95ea9f16f9d94bbdbe9edfe"
+checksum = "33a8841208ab59958c0bac5118738cc3f6fa91d7bdef7751807344622008e803"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2349a66d10d6e9f214a78572a4470b9fc2e805e49327c3c1ac6870951020b9"
+checksum = "147fc4f999eb2367467b09390d991811ca8d951ccc704246f3ddcea9e413a435"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6769758c5718026d03bf55557c1cea78ab6672e4c5d8efcfef853d6162cdb"
+checksum = "18b2d832fbf4115a139981ad5a3823bc579505274faa1c74cdef1e90fc4a4b1d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835619f6a7804d6cee64772069aa0e9e30407a9980cddb7d40ab569207ff72f5"
+checksum = "9567d6ede64654fa8edf3a3be22d0e8a2d672648aacb17476c5b3f5ca70ca1e6"
 dependencies = [
  "anyhow",
  "fuel-chain-config",
@@ -2030,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.32.2"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b7ec28dbf349bbc097e7e45ee711046088fe0365261f16105c842a4db354d"
+checksum = "b44b707a20ce7b4fd7cd3451e672552e9851fd9024422d68a875f6b12ab184e5"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.6",
+ "test-utils",
  "tokio",
 ]
 
@@ -4527,6 +4528,8 @@ version = "0.1.0"
 dependencies = [
  "ethers",
  "fuels",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Forc.lock
+++ b/Forc.lock
@@ -5,7 +5,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-E6BBD1A08F478960'
+source = 'path+from-root-F3A20BA79C738864'
 
 [[package]]
 name = 'hyperlane-ism-test'
@@ -80,5 +80,5 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.32.2#b9996f13463c324e256014935c053c334b880ab5'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.33.1#acd4c1e0fbdc406800a06c845430a80dd3560fcc'
 dependencies = ['core']

--- a/Forc.lock
+++ b/Forc.lock
@@ -5,7 +5,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-F3A20BA79C738864'
+source = 'path+from-root-894BF76E6DA2FFD3'
 
 [[package]]
 name = 'hyperlane-ism-test'
@@ -80,5 +80,5 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.33.1#acd4c1e0fbdc406800a06c845430a80dd3560fcc'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.35.3#5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff'
 dependencies = ['core']

--- a/Forc.toml
+++ b/Forc.toml
@@ -1,13 +1,13 @@
 [workspace]
 
 members = [
-    "bytes-extended",
-    "hyperlane-interfaces",
-    "hyperlane-message",
-    "hyperlane-message-test",
-    "merkle",
-    "merkle-test",
-    "hyperlane-mailbox",
-    "hyperlane-ism-test",
-    "hyperlane-msg-recipient-test"
+  "bytes-extended",
+  "hyperlane-interfaces",
+  "hyperlane-message",
+  "hyperlane-message-test",
+  "merkle",
+  "merkle-test",
+  "hyperlane-mailbox",
+  "hyperlane-ism-test",
+  "hyperlane-msg-recipient-test",
 ]

--- a/bytes-extended/src/main.sw
+++ b/bytes-extended/src/main.sw
@@ -258,18 +258,6 @@ impl Bytes {
             logd zero zero ptr bytes; // Log the next `bytes` number of bytes starting from `ptr`
         };
     }
-
-    /// Performs a keccak256 of all bytes.
-    /// Heavily inspired by the keccak256 implementation:
-    /// https://github.com/FuelLabs/sway/blob/79c0a5e4bb52b04f791e7413853a1c9337ab0c27/sway-lib-std/src/hash.sw#L38
-    pub fn keccak256(self) -> b256 {
-        let mut result_buffer: b256 = ZERO_B256;
-        // See https://fuellabs.github.io/fuel-specs/master/vm/instruction_set.html#k256-keccak-256
-        asm(hash: result_buffer, ptr: self.buf.ptr(), bytes: self.len) {
-            k256 hash ptr bytes; // Hash the next `bytes` number of bytes starting from `ptr` into `hash`
-            hash: b256 // Return the hash
-        }
-    }
 }
 
 // ==================================================

--- a/bytes-extended/src/mem.sw
+++ b/bytes-extended/src/mem.sw
@@ -26,7 +26,7 @@ impl CopyTypeWrapper {
     /// Note that the value property of the struct is a u64,
     /// so the stored value will be left-padded with zeroes to
     /// fit within 64 bits.
-    fn with_value<T>(value: T) -> Self {
+    fn with_value(value: u64) -> Self {
         Self { value }
     }
 

--- a/hyperlane-interfaces/src/main.sw
+++ b/hyperlane-interfaces/src/main.sw
@@ -36,7 +36,7 @@ abi Mailbox {
     /// ### Arguments
     ///
     /// * `module` - Address implementing ISM interface.
-    #[storage(read,write)]
+    #[storage(read, write)]
     fn set_default_ism(module: ContractId);
 
     /// Gets the default ISM used for message verification.

--- a/hyperlane-ism-test/src/main.sw
+++ b/hyperlane-ism-test/src/main.sw
@@ -4,7 +4,7 @@ use hyperlane_interfaces::InterchainSecurityModule;
 use hyperlane_message::Message;
 
 storage {
-    accept: bool = true
+    accept: bool = true,
 }
 
 abi TestISM {
@@ -22,6 +22,9 @@ impl TestISM for Contract {
 impl InterchainSecurityModule for Contract {
     #[storage(read, write)]
     fn verify(metadata: Vec<u8>, message: Message) -> bool {
+        // To ignore a compiler warning that no storage writes are made.
+        storage.accept = storage.accept;
+
         return storage.accept;
     }
 }

--- a/hyperlane-mailbox/Cargo.toml
+++ b/hyperlane-mailbox/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }

--- a/hyperlane-mailbox/Cargo.toml
+++ b/hyperlane-mailbox/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }

--- a/hyperlane-mailbox/Cargo.toml
+++ b/hyperlane-mailbox/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.33", features = ["fuel-core-lib"] }
+fuels = { version = "0.36", features = ["fuel-core-lib"] }
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }

--- a/hyperlane-mailbox/src/main.sw
+++ b/hyperlane-mailbox/src/main.sw
@@ -95,7 +95,7 @@ impl Mailbox for Contract {
 
     #[storage(read)]
     fn delivered(message_id: b256) -> bool {
-        storage.delivered.get(message_id)
+        delivered(message_id)
     }
 
     #[storage(read, write)]
@@ -107,7 +107,7 @@ impl Mailbox for Contract {
         require(message.destination() == LOCAL_DOMAIN, "!destination");
 
         let id = message.id();
-        require(storage.delivered.get(id) == false, "delivered");
+        require(!delivered(id), "delivered");
         storage.delivered.insert(id, true);
 
         let msg_recipient = abi(MessageRecipient, message.recipient());
@@ -175,6 +175,11 @@ fn count() -> u32 {
 #[storage(read)]
 fn root() -> b256 {
     storage.merkle_tree.root()
+}
+
+#[storage(read)]
+fn delivered(message_id: b256) -> bool {
+    storage.delivered.get(message_id).unwrap_or(false)
 }
 
 /// Gets the b256 representation of the msg_sender.

--- a/hyperlane-mailbox/tests/harness.rs
+++ b/hyperlane-mailbox/tests/harness.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use ethers::types::H256;
 use fuels::{
     prelude::*,
-    tx::{ContractId, Receipt}, types::{Bits256, Identity},
+    tx::{ContractId, Receipt},
+    types::{Bits256, Identity},
 };
 use hyperlane_core::{Decode, HyperlaneMessage as HyperlaneAgentMessage};
 use test_utils::{
@@ -20,11 +21,7 @@ mod mailbox_contract {
     ));
 }
 
-use crate::mailbox_contract::{
-    Message as ContractMessage,
-    Mailbox,
-    OwnershipTransferredEvent,
-};
+use crate::mailbox_contract::{Mailbox, Message as ContractMessage, OwnershipTransferredEvent};
 
 mod test_interchain_security_module_contract {
     use fuels::prelude::abigen;
@@ -101,13 +98,25 @@ async fn get_contract_instance() -> (Mailbox, Bech32ContractId, Bech32ContractId
 
     let initial_owner_wallet =
         funded_wallet_with_private_key(&mailbox.wallet(), INTIAL_OWNER_PRIVATE_KEY)
+            .await
+            .unwrap();
+
+    let raw_ism_id: ContractId = ism_id.clone().into();
+    mailbox
+        .with_wallet(initial_owner_wallet)
+        .unwrap()
+        .methods()
+        .set_default_ism(raw_ism_id)
+        .call()
         .await
         .unwrap();
 
-    let raw_ism_id: ContractId = ism_id.clone().into();
-    mailbox.with_wallet(initial_owner_wallet).unwrap().methods().set_default_ism(raw_ism_id).call().await.unwrap();
-
-    let default_ism = mailbox.methods().get_default_ism().simulate().await.unwrap();
+    let default_ism = mailbox
+        .methods()
+        .get_default_ism()
+        .simulate()
+        .await
+        .unwrap();
     assert_eq!(default_ism.value, raw_ism_id);
 
     (mailbox, ism_id, msg_recipient_id, wallet)
@@ -115,14 +124,26 @@ async fn get_contract_instance() -> (Mailbox, Bech32ContractId, Bech32ContractId
 
 // Gets the wallet address from the `Mailbox` instance, and
 // creates a test message with that address as the sender.
-fn test_message(mailbox: &Mailbox, recipient: Bech32ContractId, outbound: bool) -> HyperlaneAgentMessage {
+fn test_message(
+    mailbox: &Mailbox,
+    recipient: Bech32ContractId,
+    outbound: bool,
+) -> HyperlaneAgentMessage {
     let sender: Address = mailbox.wallet().address().into();
     HyperlaneAgentMessage {
         version: 0u8,
         nonce: 0u32,
-        origin: if outbound { TEST_LOCAL_DOMAIN } else { TEST_REMOTE_DOMAIN },
+        origin: if outbound {
+            TEST_LOCAL_DOMAIN
+        } else {
+            TEST_REMOTE_DOMAIN
+        },
         sender: H256::from(*sender),
-        destination: if outbound { TEST_REMOTE_DOMAIN } else { TEST_LOCAL_DOMAIN },
+        destination: if outbound {
+            TEST_REMOTE_DOMAIN
+        } else {
+            TEST_LOCAL_DOMAIN
+        },
         recipient: H256::from(*recipient.hash()),
         body: vec![10u8; 100],
     }
@@ -279,7 +300,9 @@ async fn transfer_ownership_test_helper(
         .methods()
         .transfer_ownership(new_owner.clone())
         .tx_params(TxParameters::default())
-        .call().await.unwrap();
+        .call()
+        .await
+        .unwrap();
 
     // Ensure the owner is now the new owner
     let owner = mailbox.methods().owner().simulate().await.unwrap().value;
@@ -372,22 +395,19 @@ async fn test_process_id() {
 
     let process_call = mailbox
         .methods()
-        .process(
-            metadata.clone(),
-            agent_message.clone().into(),
-        )
+        .process(metadata.clone(), agent_message.clone().into())
         .set_contract_ids(&contract_inputs)
         .tx_params(TxParameters::new(None, Some(1_200_000), None))
         .call()
         .await
         .unwrap();
-        
+
     let message_id = &process_call.get_logs_with_type::<Bits256>().unwrap()[0];
-    
+
     // Assert equality of the message ID
     assert_eq!(agent_message_id, bits256_to_h256(*message_id));
 }
-    
+
 #[tokio::test]
 async fn test_process_handle() {
     let (mailbox, ism_id, recipient_id, wallet) = get_contract_instance().await;
@@ -400,21 +420,18 @@ async fn test_process_handle() {
 
     mailbox
         .methods()
-        .process(
-            metadata.clone(),
-            agent_message.clone().into(),
-        )
+        .process(metadata.clone(), agent_message.clone().into())
         .set_contract_ids(&contract_inputs)
         .tx_params(TxParameters::new(None, Some(1_200_000), None))
         .call()
         .await
         .unwrap();
-        
+
     let msg_recipient = TestMessageRecipient::new(recipient_id, wallet);
     let handled = msg_recipient.methods().handled().simulate().await.unwrap();
     assert!(handled.value);
 }
-    
+
 #[tokio::test]
 async fn test_process_deliver_twice() {
     let (mailbox, ism_id, recipient_id, _) = get_contract_instance().await;
@@ -428,10 +445,7 @@ async fn test_process_deliver_twice() {
 
     mailbox
         .methods()
-        .process(
-            metadata.clone(),
-            agent_message.clone().into(),
-        )
+        .process(metadata.clone(), agent_message.clone().into())
         .set_contract_ids(&contract_inputs)
         .tx_params(TxParameters::new(None, Some(1_200_000), None))
         .call()
@@ -443,22 +457,20 @@ async fn test_process_deliver_twice() {
         .delivered(h256_to_bits256(agent_message_id))
         .simulate()
         .await
-        .unwrap().value;
-    
+        .unwrap()
+        .value;
+
     assert!(delivered);
-    
+
     let process_delivered_error = mailbox
         .methods()
-        .process(
-            metadata.clone(),
-            agent_message.clone().into(),
-        )
+        .process(metadata.clone(), agent_message.clone().into())
         .set_contract_ids(&contract_inputs)
         .tx_params(TxParameters::new(None, Some(1_200_000), None))
         .call()
         .await
         .unwrap_err();
-    
+
     assert_eq!(get_revert_string(process_delivered_error), "delivered");
 }
 
@@ -477,10 +489,7 @@ async fn test_process_module_reject() {
 
     let process_module_error = mailbox
         .methods()
-        .process(
-            metadata,
-            agent_message.into(),
-        )
+        .process(metadata, agent_message.into())
         .set_contract_ids(&contract_inputs)
         .tx_params(TxParameters::new(None, Some(1_200_000), None))
         .call()

--- a/hyperlane-message-test/Cargo.toml
+++ b/hyperlane-message-test/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.33", features = ["fuel-core-lib"] }
+fuels = { version = "0.36", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }

--- a/hyperlane-message-test/Cargo.toml
+++ b/hyperlane-message-test/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }

--- a/hyperlane-message-test/Cargo.toml
+++ b/hyperlane-message-test/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "253e5f8" }
 test-utils = { path = "../test-utils" }

--- a/hyperlane-message-test/tests/harness.rs
+++ b/hyperlane-message-test/tests/harness.rs
@@ -12,7 +12,10 @@ use test_utils::{
 };
 
 // Load abi from json
-abigen!(TestMessage, "hyperlane-message-test/out/debug/hyperlane-message-test-abi.json");
+abigen!(Contract(
+    name = "TestMessage",
+    abi = "hyperlane-message-test/out/debug/hyperlane-message-test-abi.json"
+));
 
 async fn get_contract_instance() -> (TestMessage, ContractId) {
     // Launch a local network and deploy the contract

--- a/hyperlane-message-test/tests/harness.rs
+++ b/hyperlane-message-test/tests/harness.rs
@@ -1,15 +1,12 @@
 use ethers::{abi::AbiDecode, types::H256};
 use fuels::{
-    core::parameters::TxParameters,
     prelude::*,
     tx::{ContractId, Receipt},
+    types::parameters::TxParameters,
 };
 use hex::FromHex;
 use hyperlane_core::{Decode, HyperlaneMessage as HyperlaneAgentMessage};
-use test_utils::{
-    bits256_to_h256,
-    h256_to_bits256,
-};
+use test_utils::{bits256_to_h256, h256_to_bits256};
 
 // Load abi from json
 abigen!(Contract(

--- a/hyperlane-msg-recipient-test/src/main.sw
+++ b/hyperlane-msg-recipient-test/src/main.sw
@@ -15,12 +15,15 @@ const ZERO_ID: ContractId = ContractId {
 
 storage {
     module: ContractId = ZERO_ID,
-    handled: bool = false
+    handled: bool = false,
 }
 
 impl MessageRecipient for Contract {
     #[storage(read, write)]
     fn handle(origin: u32, sender: b256, message_body: Vec<u8>) {
+        // To ignore a compiler warning that no storage reads are made.
+        let _ = storage.module;
+
         storage.handled = true;
     }
 

--- a/merkle-test/Cargo.toml
+++ b/merkle-test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Trevor Porter <trevor@hyperlane.xyz>"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 serde = "1.0.147"
 serde_json = "1.0"

--- a/merkle-test/Cargo.toml
+++ b/merkle-test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Trevor Porter <trevor@hyperlane.xyz>"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.33", features = ["fuel-core-lib"] }
+fuels = { version = "0.36", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 serde = "1.0.147"
 serde_json = "1.0"

--- a/merkle-test/Cargo.toml
+++ b/merkle-test/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.12", features = ["rt", "macros"] }
 serde = "1.0.147"
 serde_json = "1.0"
 sha3 = "0.10.6"
+test-utils = { path = "../test-utils" }
 
 [[test]]
 harness = true

--- a/merkle-test/Cargo.toml
+++ b/merkle-test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Trevor Porter <trevor@hyperlane.xyz>"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 serde = "1.0.147"
 serde_json = "1.0"

--- a/merkle-test/tests/harness.rs
+++ b/merkle-test/tests/harness.rs
@@ -4,7 +4,10 @@ use sha3::{Digest, Keccak256};
 use std::{fs::File, io::Read};
 
 // Load abi from json
-abigen!(TestStorageMerkleTree, "merkle-test/out/debug/merkle-test-abi.json");
+abigen!(Contract(
+    name = "TestStorageMerkleTree",
+    abi = "merkle-test/out/debug/merkle-test-abi.json"
+));
 
 async fn get_contract_instance() -> (TestStorageMerkleTree, ContractId) {
     // Launch a local network and deploy the contract

--- a/merkle-test/tests/harness.rs
+++ b/merkle-test/tests/harness.rs
@@ -1,7 +1,8 @@
-use fuels::{prelude::*, tx::ContractId};
-use serde::{de::Deserializer, Deserialize};
+use fuels::{prelude::*, tx::ContractId, types::Bits256};
+use serde::Deserialize;
 use sha3::{Digest, Keccak256};
 use std::{fs::File, io::Read};
+use test_utils::{deserialize_bits_256, deserialize_vec_bits_256};
 
 // Load abi from json
 abigen!(Contract(
@@ -105,32 +106,6 @@ async fn satisfies_test_cases() {
             assert_eq!(proof_root.value, case.expected_root);
         }
     }
-}
-
-/// Kludge to deserialize into Bits256
-fn deserialize_bits_256<'de, D>(deserializer: D) -> Result<Bits256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let buf = String::deserialize(deserializer)?;
-
-    Bits256::from_hex_str(&buf).map_err(serde::de::Error::custom)
-}
-
-/// Kludge to deserialize into Vec<Bits256>
-fn deserialize_vec_bits_256<'de, D>(deserializer: D) -> Result<Vec<Bits256>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let strs = Vec::<String>::deserialize(deserializer)?;
-
-    let mut vec = Vec::with_capacity(strs.len());
-
-    for s in strs.iter() {
-        vec.push(Bits256::from_hex_str(s).map_err(serde::de::Error::custom)?);
-    }
-
-    Ok(vec)
 }
 
 /// Reads merkle test case json file and returns a vector of `TestCase`s

--- a/merkle/src/main.sw
+++ b/merkle/src/main.sw
@@ -81,7 +81,7 @@ impl StorageMerkleTree {
     // Reads an element of `branch` from storage.
     #[storage(read)]
     pub fn get_branch(self, index: u64) -> b256 {
-        get(StorageMerkleTree::get_branch_storage_key(index))
+        get(StorageMerkleTree::get_branch_storage_key(index)).unwrap_or(ZERO_B256)
     }
 
     // Writes an element of `branch` into storage.
@@ -93,7 +93,7 @@ impl StorageMerkleTree {
     // Reads the `count` from storage.
     #[storage(read)]
     pub fn get_count(self) -> u64 {
-        get(__get_storage_key())
+        get(__get_storage_key()).unwrap_or(0)
     }
 
     // Writes the `count` into storage.

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 serde = "1.0.147"
 serde_json = "1.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.33", features = ["fuel-core-lib"] }
+fuels = { version = "0.36", features = ["fuel-core-lib"] }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
 fuels = { version = "0.36", features = ["fuel-core-lib"] }
+serde = "1.0.147"
+serde_json = "1.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2022-12-05-01", default-features = false, features = ['legacy'] }
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 
 use ethers::types::H256;
 use fuels::{
-    types::{Bits256, errors::Error},
     prelude::{Bech32Address, TxParameters},
     signers::{fuel_crypto::SecretKey, WalletUnlocked},
     tx::{AssetId, Receipt},
+    types::{errors::Error, Bits256},
 };
 use serde::{de::Deserializer, Deserialize};
 
@@ -20,7 +20,7 @@ pub fn bits256_to_h256(b: Bits256) -> H256 {
 // Given an Error from a call or simulation, returns the revert reason.
 // Panics if it's unable to find the revert reason.
 pub fn get_revert_string(call_error: Error) -> String {
-    let receipts = if let Error::RevertTransactionError{ receipts, .. } = call_error {
+    let receipts = if let Error::RevertTransactionError { receipts, .. } = call_error {
         receipts
     } else {
         panic!(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -19,8 +19,8 @@ pub fn bits256_to_h256(b: Bits256) -> H256 {
 // Given an Error from a call or simulation, returns the revert reason.
 // Panics if it's unable to find the revert reason.
 pub fn get_revert_string(call_error: Error) -> String {
-    let receipts = if let Error::RevertTransactionError(_, r) = call_error {
-        r
+    let receipts = if let Error::RevertTransactionError{ receipts, .. } = call_error {
+        receipts
     } else {
         panic!(
             "Error is not a RevertTransactionError. Error: {:?}",

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -2,11 +2,10 @@ use std::str::FromStr;
 
 use ethers::types::H256;
 use fuels::{
-    core::types::Bits256,
+    types::{Bits256, errors::Error},
     prelude::{Bech32Address, TxParameters},
     signers::{fuel_crypto::SecretKey, WalletUnlocked},
     tx::{AssetId, Receipt},
-    types::errors::Error,
 };
 
 pub fn h256_to_bits256(h: H256) -> Bits256 {


### PR DESCRIPTION
* Updates to forc 0.35 and fuels-rs 0.37
  * Some changes to imports & types
  * Upstream bytes added a keccak function themselves
* There are a couple warnings - all seem to be innocuous false positives (e.g. an unused variable that is actually used to set the initial storage, or forc complaining about a storage read after calling out to an external contract). Will revisit at some point