### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: install fuelup
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s -- --no-modify-path
+          # Using -L to deal with redirects, see https://github.com/FuelLabs/sway/issues/4309
+          curl -L https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s -- --no-modify-path
           echo "$HOME/.fuelup/bin" >> $GITHUB_PATH
       - run: forc build
       - run: forc test


### PR DESCRIPTION
The suggested fuelup installation curl command doesn't work anymore. See https://github.com/FuelLabs/sway/issues/4309 for details. Temporarily removing all the tls commands to get it to work