### PR TITLE
Overhead IGP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
+name = "overhead-igp"
+version = "0.1.0"
+dependencies = [
+ "fuels",
+ "test-utils",
+ "tokio",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "contracts/hyperlane-mailbox",
     "contracts/hyperlane-message-test",
     "contracts/igp/interchain-gas-paymaster",
+    "contracts/igp/overhead-igp",
     "contracts/igp/storage-gas-oracle",
     "contracts/merkle-test",
     "test-utils",

--- a/Forc.lock
+++ b/Forc.lock
@@ -79,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = 'overhead-igp'
+source = 'member'
+dependencies = [
+    'hyperlane_interfaces',
+    'ownership',
+    'std',
+]
+
+[[package]]
 name = 'ownership'
 source = 'path+from-root-D26B060B9C691B9B'
 dependencies = ['std']
@@ -99,5 +108,13 @@ source = 'member'
 dependencies = [
     'hyperlane_interfaces',
     'ownership',
+    'std',
+]
+
+[[package]]
+name = 'interchain-gas-paymaster-test'
+source = 'member'
+dependencies = [
+    'hyperlane_interfaces',
     'std',
 ]

--- a/Forc.toml
+++ b/Forc.toml
@@ -10,6 +10,8 @@ members = [
   "contracts/hyperlane-ism-test",
   "contracts/hyperlane-msg-recipient-test",
   "contracts/igp/interchain-gas-paymaster",
-  "contracts/std-lib-extended",
+  "contracts/igp/overhead-igp",
   "contracts/igp/storage-gas-oracle",
+  "contracts/igp/interchain-gas-paymaster-test",
+  "contracts/std-lib-extended",
 ]

--- a/contracts/hyperlane-interfaces/src/igp.sw
+++ b/contracts/hyperlane-interfaces/src/igp.sw
@@ -23,6 +23,13 @@ abi GasOracle {
     fn get_exchange_rate_and_gas_price(domain: u32) -> RemoteGasData;
 }
 
+/// Logged when a gas payment is made.
+pub struct GasPaymentEvent {
+    message_id: b256,
+    gas_amount: u64,
+    payment: u64,
+}
+
 /// A contract to allow users to pay for interchain gas.
 abi InterchainGasPaymaster {
     #[storage(read, write)]

--- a/contracts/igp/interchain-gas-paymaster-test/.gitignore
+++ b/contracts/igp/interchain-gas-paymaster-test/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/contracts/igp/interchain-gas-paymaster-test/Forc.toml
+++ b/contracts/igp/interchain-gas-paymaster-test/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Trevor Porter"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "interchain-gas-paymaster-test"
+
+[dependencies]
+hyperlane_interfaces = { path = "../../hyperlane-interfaces" }

--- a/contracts/igp/interchain-gas-paymaster-test/src/main.sw
+++ b/contracts/igp/interchain-gas-paymaster-test/src/main.sw
@@ -1,0 +1,63 @@
+contract;
+
+use std::{
+    call_frames::msg_asset_id,
+    constants::BASE_ASSET_ID,
+    context::msg_amount,
+};
+
+use hyperlane_interfaces::igp::{
+    GasPaymentEvent,
+    InterchainGasPaymaster,
+};
+
+/// Logged when `pay_for_gas` is called. Used to easily confirm the exact call made to the contract.
+struct PayForGasCalled {
+    message_id: b256,
+    destination_domain: u32,
+    gas_amount: u64,
+    refund_address: Identity,
+}
+
+/// Logged when `quote_gas_payment` is called. Used to easily confirm the exact call made to the contract.
+struct QuoteGasPaymentCalled {
+    destination_domain: u32,
+    gas_amount: u64,
+}
+
+// An IGP intended to be used for testing purposes
+
+impl InterchainGasPaymaster for Contract {
+    #[storage(read, write)]
+    #[payable]
+    fn pay_for_gas(message_id: b256, destination_domain: u32, gas_amount: u64, refund_address: Identity) {
+        require(msg_asset_id() == BASE_ASSET_ID, "Must pay interchain gas in base asset");
+        require(msg_amount() > 0, "Must pay at least 1 token for interchain gas");
+
+        // Log the IGP-compliant GasPaymentEvent
+        log(GasPaymentEvent {
+            message_id,
+            gas_amount,
+            payment: msg_amount(),
+        });
+
+        // Logged to make it easy to confirm the exact call made to this contract
+        log(PayForGasCalled {
+            message_id,
+            destination_domain,
+            gas_amount,
+            refund_address,
+        });
+    }
+
+    #[storage(read)]
+    fn quote_gas_payment(destination_domain: u32, gas_amount: u64) -> u64 {
+        // Logged to make it easy to confirm the exact call made to this contract
+        log(QuoteGasPaymentCalled {
+            destination_domain,
+            gas_amount,
+        });
+
+        1
+    }
+}

--- a/contracts/igp/interchain-gas-paymaster-test/src/main.sw
+++ b/contracts/igp/interchain-gas-paymaster-test/src/main.sw
@@ -25,8 +25,10 @@ struct QuoteGasPaymentCalled {
     gas_amount: u64,
 }
 
-// An IGP intended to be used for testing purposes
-
+/// NOTE: This contract is for testing purposes only. It is not intended to be used in production.
+///
+/// This contract implements the IGP interface and charges at least 1 base token. Intended to be used
+/// by tests to avoid needing to set up gas oracles with the canonical IGP contract.
 impl InterchainGasPaymaster for Contract {
     #[storage(read, write)]
     #[payable]

--- a/contracts/igp/interchain-gas-paymaster/src/interface.sw
+++ b/contracts/igp/interchain-gas-paymaster/src/interface.sw
@@ -17,13 +17,6 @@ pub struct GasOracleSetEvent {
     gas_oracle: b256,
 }
 
-/// Logged when a gas payment is made.
-pub struct GasPaymentEvent {
-    message_id: b256,
-    gas_amount: u64,
-    payment: u64,
-}
-
 /// Functions specific to on chain fee quoting.
 abi OnChainFeeQuoting {
     #[storage(read, write)]

--- a/contracts/igp/interchain-gas-paymaster/src/main.sw
+++ b/contracts/igp/interchain-gas-paymaster/src/main.sw
@@ -16,7 +16,7 @@ use std::{
 
 use std_lib_extended::{option::*, result::*};
 
-use hyperlane_interfaces::igp::{GasOracle, InterchainGasPaymaster, RemoteGasData};
+use hyperlane_interfaces::igp::{GasOracle, GasPaymentEvent, InterchainGasPaymaster, RemoteGasData};
 
 use ownership::{interface::Ownable, log_ownership_transferred, require_msg_sender};
 
@@ -25,7 +25,6 @@ use interface::{
     Claimable,
     ClaimEvent,
     GasOracleSetEvent,
-    GasPaymentEvent,
     OnChainFeeQuoting,
 };
 

--- a/contracts/igp/overhead-igp/.gitignore
+++ b/contracts/igp/overhead-igp/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/contracts/igp/overhead-igp/Cargo.toml
+++ b/contracts/igp/overhead-igp/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "overhead-igp"
+description = "A cargo-generate template for Rust + Sway integration testing."
+version = "0.1.0"
+edition = "2021"
+authors = ["Trevor Porter <trkporter@ucdavis.edu>"]
+license = "Apache-2.0"
+
+[dev-dependencies]
+fuels = { workspace = true, features = ["fuel-core-lib"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
+test-utils = { path = "../../../test-utils" }
+
+[[test]]
+harness = true
+name = "integration_tests"
+path = "tests/harness.rs"

--- a/contracts/igp/overhead-igp/Cargo.toml
+++ b/contracts/igp/overhead-igp/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "overhead-igp"
-description = "A cargo-generate template for Rust + Sway integration testing."
+description = "Tests for overhead-igp"
 version = "0.1.0"
 edition = "2021"
-authors = ["Trevor Porter <trkporter@ucdavis.edu>"]
+authors = ["Trevor Porter <trevor@hyperlane.xyz>"]
 license = "Apache-2.0"
 
 [dev-dependencies]

--- a/contracts/igp/overhead-igp/Forc.lock
+++ b/contracts/igp/overhead-igp/Forc.lock
@@ -1,0 +1,43 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-2C66FC65A00ECA96'
+
+[[package]]
+name = 'hyperlane_interfaces'
+source = 'path+from-root-A739E039AF047084'
+dependencies = [
+    'hyperlane_message',
+    'std',
+]
+
+[[package]]
+name = 'hyperlane_message'
+source = 'path+from-root-A739E039AF047084'
+dependencies = [
+    'std',
+    'std_lib_extended',
+]
+
+[[package]]
+name = 'overhead-igp'
+source = 'member'
+dependencies = [
+    'hyperlane_interfaces',
+    'ownership',
+    'std',
+]
+
+[[package]]
+name = 'ownership'
+source = 'path+from-root-A739E039AF047084'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.35.5#49eae2dd93a1957e2a2c2fb3f51b11eb3791fc24'
+dependencies = ['core']
+
+[[package]]
+name = 'std_lib_extended'
+source = 'path+from-root-A739E039AF047084'
+dependencies = ['std']

--- a/contracts/igp/overhead-igp/Forc.toml
+++ b/contracts/igp/overhead-igp/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Trevor Porter"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "overhead-igp"
+
+[dependencies]
+hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
+ownership = { path = "../../ownership" }

--- a/contracts/igp/overhead-igp/src/interface.sw
+++ b/contracts/igp/overhead-igp/src/interface.sw
@@ -7,7 +7,7 @@ pub struct GasOverheadConfig {
 }
 
 /// Logged when a destination gas overhead for a domain is set.
-pub struct DestinationGasOverheadSet {
+pub struct DestinationGasOverheadSetEvent {
     config: GasOverheadConfig,
 }
 

--- a/contracts/igp/overhead-igp/src/interface.sw
+++ b/contracts/igp/overhead-igp/src/interface.sw
@@ -13,11 +13,14 @@ pub struct DestinationGasOverheadSet {
 
 /// An InterchainGasPaymaster that adds configured gas overheads to gas amounts.
 abi OverheadIgp {
+    /// Sets the gas overheads for destination domains.
     #[storage(read, write)]
     fn set_destination_gas_overheads(configs: Vec<GasOverheadConfig>);
 
+    /// Gets the gas overhead for a destination domain.
     #[storage(read)]
     fn destination_gas_overhead(domain: u32) -> u64;
 
+    /// Gets the inner IGP contract ID.
     fn inner_igp() -> b256;
 }

--- a/contracts/igp/overhead-igp/src/interface.sw
+++ b/contracts/igp/overhead-igp/src/interface.sw
@@ -17,5 +17,7 @@ abi OverheadIgp {
     fn set_destination_gas_overheads(configs: Vec<GasOverheadConfig>);
 
     #[storage(read)]
-    fn get_destination_gas_overhead(domain: u32) -> u64;
+    fn destination_gas_overhead(domain: u32) -> u64;
+
+    fn inner_igp() -> b256;
 }

--- a/contracts/igp/overhead-igp/src/interface.sw
+++ b/contracts/igp/overhead-igp/src/interface.sw
@@ -1,0 +1,21 @@
+library interface;
+
+/// A configuration for a domain and its gas overhead.
+pub struct GasOverheadConfig {
+    domain: u32,
+    gas_overhead: u64,
+}
+
+/// Logged when a destination gas overhead for a domain is set.
+pub struct DestinationGasOverheadSet {
+    config: GasOverheadConfig,
+}
+
+/// An InterchainGasPaymaster that adds configured gas overheads to gas amounts.
+abi OverheadIgp {
+    #[storage(read, write)]
+    fn set_destination_gas_overheads(configs: Vec<GasOverheadConfig>);
+
+    #[storage(read)]
+    fn get_destination_gas_overhead(domain: u32) -> u64;
+}

--- a/contracts/igp/overhead-igp/src/main.sw
+++ b/contracts/igp/overhead-igp/src/main.sw
@@ -1,0 +1,96 @@
+contract;
+
+dep interface;
+
+use std::constants::ZERO_B256;
+
+use hyperlane_interfaces::igp::InterchainGasPaymaster;
+use ownership::{interface::Ownable, log_ownership_transferred, require_msg_sender};
+
+use interface::{
+    DestinationGasOverheadSet,
+    GasOverheadConfig,
+    OverheadIgp,
+};
+
+// TODO: set this at compile / deploy time.
+// NOTE for now this is temporarily set to the address of a PUBLICLY KNOWN
+// PRIVATE KEY, which is the first default account when running fuel-client locally.
+const INITIAL_OWNER: Option<Identity> = Option::Some(Identity::Address(Address::from(0x6b63804cfbf9856e68e5b6e7aef238dc8311ec55bec04df774003a2c96e0418e)));
+
+configurable {
+    /// The inner IGP contract. Expected to be set at deploy time.
+    inner_igp_id: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000,
+}
+
+storage {
+    owner: Option<Identity> = INITIAL_OWNER,
+    destination_gas_overheads: StorageMap<u32, u64> = StorageMap {},
+}
+
+impl OverheadIgp for Contract {
+    #[storage(read, write)]
+    fn set_destination_gas_overheads(configs: Vec<GasOverheadConfig>) {
+        // Only owner can call
+        require_msg_sender(storage.owner);
+
+        let count = configs.len();
+        let mut i = 0;
+        while i < count {
+            let config = configs.get(i).unwrap();
+            storage.destination_gas_overheads.insert(
+                config.domain,
+                config.gas_overhead,
+            );
+            log(DestinationGasOverheadSet {
+                config,
+            });
+
+            i += 1;
+        }
+    }
+
+    #[storage(read)]
+    fn get_destination_gas_overhead(domain: u32) -> u64 {
+        get_destination_gas_overhead(domain)
+    }
+}
+
+impl InterchainGasPaymaster for Contract {
+    #[storage(read, write)]
+    #[payable]
+    fn pay_for_gas(message_id: b256, destination_domain: u32, gas_amount: u64, refund_address: Identity) {
+        let inner_igp = abi(InterchainGasPaymaster, inner_igp_id);
+        inner_igp.pay_for_gas(message_id, destination_domain, gas_amount + get_destination_gas_overhead(destination_domain), refund_address);
+    }
+
+    #[storage(read)]
+    fn quote_gas_payment(destination_domain: u32, gas_amount: u64) -> u64 {
+        let inner_igp = abi(InterchainGasPaymaster, inner_igp_id);
+        inner_igp.quote_gas_payment(destination_domain, gas_amount + get_destination_gas_overhead(destination_domain))
+    }
+}
+
+impl Ownable for Contract {
+    /// Gets the current owner.
+    #[storage(read)]
+    fn owner() -> Option<Identity> {
+        storage.owner
+    }
+
+    /// Transfers ownership to `new_owner`.
+    /// Reverts if the msg_sender is not the current owner.
+    #[storage(read, write)]
+    fn transfer_ownership(new_owner: Option<Identity>) {
+        let old_owner = storage.owner;
+        require_msg_sender(old_owner);
+
+        storage.owner = new_owner;
+        log_ownership_transferred(old_owner, new_owner);
+    }
+}
+
+#[storage(read)]
+fn get_destination_gas_overhead(domain: u32) -> u64 {
+    storage.destination_gas_overheads.get(domain).unwrap_or(0)
+}

--- a/contracts/igp/overhead-igp/src/main.sw
+++ b/contracts/igp/overhead-igp/src/main.sw
@@ -7,7 +7,7 @@ use std::{call_frames::msg_asset_id, constants::ZERO_B256, context::msg_amount};
 use hyperlane_interfaces::igp::InterchainGasPaymaster;
 use ownership::{interface::Ownable, log_ownership_transferred, require_msg_sender};
 
-use interface::{DestinationGasOverheadSet, GasOverheadConfig, OverheadIgp};
+use interface::{DestinationGasOverheadSetEvent, GasOverheadConfig, OverheadIgp};
 
 // TODO: set this at compile / deploy time.
 // NOTE for now this is temporarily set to the address of a PUBLICLY KNOWN
@@ -41,7 +41,7 @@ impl OverheadIgp for Contract {
         while i < count {
             let config = configs.get(i).unwrap();
             storage.destination_gas_overheads.insert(config.domain, config.gas_overhead);
-            log(DestinationGasOverheadSet { config });
+            log(DestinationGasOverheadSetEvent { config });
 
             i += 1;
         }

--- a/contracts/igp/overhead-igp/tests/harness.rs
+++ b/contracts/igp/overhead-igp/tests/harness.rs
@@ -132,7 +132,6 @@ async fn test_pay_for_gas() {
             TEST_GAS_AMOUNT,
             refund_address.clone(),
         )
-        // Pay 1 base asset
         .call_params(
             CallParameters::default()
                 .set_asset_id(BASE_ASSET_ID)

--- a/contracts/igp/overhead-igp/tests/harness.rs
+++ b/contracts/igp/overhead-igp/tests/harness.rs
@@ -1,0 +1,264 @@
+use std::str::FromStr;
+
+use fuels::{
+    prelude::*,
+    types::{Bits256, Identity},
+};
+
+// Load abi from json
+abigen!(Contract(
+    name = "OverheadIgp",
+    abi = "contracts/igp/overhead-igp/out/debug/overhead-igp-abi.json"
+));
+
+mod test_igp_contract {
+    use fuels::prelude::abigen;
+
+    abigen!(Contract(
+        name = "TestInterchainGasPaymaster",
+        abi = "contracts/igp/interchain-gas-paymaster-test/out/debug/interchain-gas-paymaster-test-abi.json"
+    ));
+}
+
+use test_igp_contract::TestInterchainGasPaymaster;
+use test_utils::{funded_wallet_with_private_key, get_revert_string};
+
+const INTIAL_OWNER_PRIVATE_KEY: &str =
+    "0xde97d8624a438121b86a1956544bd72ed68cd69f2c99555b08b1e8c51ffd511c";
+
+const TEST_DESTINATION_DOMAIN: u32 = 11111;
+const TEST_GAS_AMOUNT: u64 = 300000;
+const TEST_MESSAGE_ID: &str = "0x6ae9a99190641b9ed0c07143340612dde0e9cb7deaa5fe07597858ae9ba5fd7f";
+const TEST_REFUND_ADDRESS: &str =
+    "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+const TEST_GAS_OVERHEAD_AMOUNT: u64 = 100000;
+
+async fn get_contract_instances() -> (OverheadIgp, TestInterchainGasPaymaster) {
+    // Launch a local network and deploy the contract
+    let mut wallets = launch_custom_provider_and_get_wallets(
+        WalletsConfig::new(
+            Some(1),             /* Single wallet */
+            Some(1),             /* Single coin (UTXO) */
+            Some(1_000_000_000), /* Amount per coin */
+        ),
+        None,
+        None,
+    )
+    .await;
+    let wallet = wallets.pop().unwrap();
+
+    let test_igp_id = Contract::deploy(
+        "../interchain-gas-paymaster-test/out/debug/interchain-gas-paymaster-test.bin",
+        &wallet,
+        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
+            "../interchain-gas-paymaster-test/out/debug/interchain-gas-paymaster-test-storage_slots.json".to_string(),
+            vec![],
+        )),
+    )
+    .await
+    .unwrap();
+
+    let test_igp = TestInterchainGasPaymaster::new(test_igp_id.clone(), wallet.clone());
+
+    let overhead_igp_configurables =
+        OverheadIgpConfigurables::default().set_INNER_IGP_ID(Bits256(test_igp_id.hash().into()));
+    let overhead_igp_id = Contract::deploy(
+        "./out/debug/overhead-igp.bin",
+        &wallet,
+        DeployConfiguration::default()
+            .set_storage_configuration(StorageConfiguration::new(
+                "./out/debug/overhead-igp-storage_slots.json".to_string(),
+                vec![],
+            ))
+            .set_configurables(overhead_igp_configurables),
+    )
+    .await
+    .unwrap();
+
+    let overhead_igp = OverheadIgp::new(overhead_igp_id.clone(), wallet.clone());
+
+    // Set the destination gas overhead for the test destination domain
+    let owner_wallet = initial_owner_wallet(&wallet).await.unwrap();
+    overhead_igp
+        .with_wallet(owner_wallet)
+        .unwrap()
+        .methods()
+        .set_destination_gas_overheads(vec![GasOverheadConfig {
+            domain: TEST_DESTINATION_DOMAIN,
+            gas_overhead: TEST_GAS_OVERHEAD_AMOUNT,
+        }])
+        .call()
+        .await
+        .unwrap();
+
+    (overhead_igp, test_igp)
+}
+
+async fn initial_owner_wallet(funder: &WalletUnlocked) -> Result<WalletUnlocked> {
+    funded_wallet_with_private_key(funder, INTIAL_OWNER_PRIVATE_KEY).await
+}
+
+#[tokio::test]
+async fn test_inner_igp_set() {
+    let (overhead_igp, test_igp) = get_contract_instances().await;
+
+    // Sanity check that the inner IGP is set
+    let inner_igp_id = overhead_igp
+        .methods()
+        .inner_igp()
+        .simulate()
+        .await
+        .unwrap()
+        .value;
+    assert_eq!(inner_igp_id, Bits256(test_igp.contract_id().hash().into()));
+}
+
+// ============ pay_for_gas ============
+
+#[tokio::test]
+async fn test_pay_for_gas() {
+    let (overhead_igp, test_igp) = get_contract_instances().await;
+
+    let message_id = Bits256::from_hex_str(TEST_MESSAGE_ID).unwrap();
+    let refund_address = Identity::Address(Address::from_str(TEST_REFUND_ADDRESS).unwrap());
+
+    let call = overhead_igp
+        .methods()
+        .pay_for_gas(
+            message_id,
+            TEST_DESTINATION_DOMAIN,
+            TEST_GAS_AMOUNT,
+            refund_address.clone(),
+        )
+        // Pay 1 base asset
+        .call_params(
+            CallParameters::default()
+                .set_asset_id(BASE_ASSET_ID)
+                .set_amount(1),
+        )
+        .unwrap()
+        .estimate_tx_dependencies(Some(5))
+        .await
+        .unwrap()
+        .call()
+        .await
+        .unwrap();
+
+    // Check that the inner IGP was called with the correct parameters
+    let events = test_igp
+        .log_decoder()
+        .get_logs_with_type::<test_igp_contract::PayForGasCalled>(&call.receipts)
+        .unwrap();
+    assert_eq!(
+        events,
+        vec![test_igp_contract::PayForGasCalled {
+            message_id: Bits256::from_hex_str(TEST_MESSAGE_ID).unwrap(),
+            destination_domain: TEST_DESTINATION_DOMAIN,
+            gas_amount: TEST_GAS_AMOUNT + TEST_GAS_OVERHEAD_AMOUNT,
+            refund_address,
+        }]
+    );
+}
+
+// ============ quote_gas_payment ============
+
+#[tokio::test]
+async fn test_quote_gas_payment() {
+    let (overhead_igp, test_igp) = get_contract_instances().await;
+
+    let call = overhead_igp
+        .methods()
+        .quote_gas_payment(TEST_DESTINATION_DOMAIN, TEST_GAS_AMOUNT)
+        .estimate_tx_dependencies(Some(5))
+        .await
+        .unwrap()
+        .simulate()
+        .await
+        .unwrap();
+
+    // Check that the inner IGP was called with the correct parameters
+    let events = test_igp
+        .log_decoder()
+        .get_logs_with_type::<test_igp_contract::QuoteGasPaymentCalled>(&call.receipts)
+        .unwrap();
+    assert_eq!(
+        events,
+        vec![test_igp_contract::QuoteGasPaymentCalled {
+            destination_domain: TEST_DESTINATION_DOMAIN,
+            gas_amount: TEST_GAS_AMOUNT + TEST_GAS_OVERHEAD_AMOUNT,
+        }]
+    );
+}
+
+// ============ set_destination_gas_overheads ============
+
+#[tokio::test]
+async fn test_set_destination_gas_overheads() {
+    let (overhead_igp, _) = get_contract_instances().await;
+
+    let owner_wallet = initial_owner_wallet(&overhead_igp.wallet()).await.unwrap();
+
+    let configs = vec![
+        GasOverheadConfig {
+            domain: TEST_DESTINATION_DOMAIN + 1,
+            gas_overhead: TEST_GAS_OVERHEAD_AMOUNT + 1,
+        },
+        GasOverheadConfig {
+            domain: TEST_DESTINATION_DOMAIN + 2,
+            gas_overhead: TEST_GAS_OVERHEAD_AMOUNT + 2,
+        },
+    ];
+
+    let call = overhead_igp
+        .with_wallet(owner_wallet)
+        .unwrap()
+        .methods()
+        .set_destination_gas_overheads(configs.clone())
+        .estimate_tx_dependencies(Some(5))
+        .await
+        .unwrap()
+        .call()
+        .await
+        .unwrap();
+
+    for config in configs.iter() {
+        assert_eq!(
+            overhead_igp
+                .methods()
+                .destination_gas_overhead(config.domain)
+                .simulate()
+                .await
+                .unwrap()
+                .value,
+            config.gas_overhead,
+        );
+    }
+
+    let events = call
+        .get_logs_with_type::<DestinationGasOverheadSet>()
+        .unwrap();
+    assert_eq!(
+        events,
+        configs
+            .into_iter()
+            .map(|config| DestinationGasOverheadSet { config })
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[tokio::test]
+async fn test_set_destination_gas_overheads_reverts_if_not_owner() {
+    let (overhead_igp, _) = get_contract_instances().await;
+
+    let call = overhead_igp
+        .methods()
+        .set_destination_gas_overheads(vec![GasOverheadConfig {
+            domain: TEST_DESTINATION_DOMAIN,
+            gas_overhead: TEST_GAS_OVERHEAD_AMOUNT,
+        }])
+        .call()
+        .await;
+
+    assert!(call.is_err());
+    assert_eq!(get_revert_string(call.err().unwrap()), "!owner");
+}


### PR DESCRIPTION
* Adds a new `overhead-igp` contract
* Adds an `interchain-gas-paymaster-test` contract that is just used for testing and doesn't require gas oracles to be configured
* Fixes #51 