### PR TITLE
Upgrade to forc 0.38 & fuels-rs 0.41, including new storage API & some quality of life changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -2212,8 +2212,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2239,8 +2239,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2255,8 +2255,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "fuel-tx",
  "fuel-types",
@@ -2269,8 +2269,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2287,8 +2287,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2316,8 +2316,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.39.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?rev=f5d08d6#f5d08d67543ee35fedc561c5c8335bb134ec24fd"
+version = "0.41.0"
+source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.41.0#adb4c9be1f1ff7c1e4cd32871458858afdca1f37"
 dependencies = [
  "bech32 0.9.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ authors = ["Abacus Works"]
 
 [workspace.dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-# fuels = { git = "https://github.com/FuelLabs/fuels-rs", rev = "f5d08d6" }
 fuels = { git = "https://github.com/FuelLabs/fuels-rs", tag = "v0.41.0" }
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "930cded" }
 hyperlane-ethereum = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "930cded" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ authors = ["Abacus Works"]
 
 [workspace.dependencies]
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", rev = "f5d08d6" }
+# fuels = { git = "https://github.com/FuelLabs/fuels-rs", rev = "f5d08d6" }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs", tag = "v0.41.0" }
 hyperlane-core = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "930cded" }
 hyperlane-ethereum = { git = "https://github.com/hyperlane-xyz/hyperlane-monorepo", rev = "930cded" }
 tokio = { version = "1.12" }

--- a/Forc.lock
+++ b/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-91563E0DA237BDEC'
+source = 'path+from-root-1AA1C8235B783A81'
 
 [[package]]
 name = 'hyperlane-ism-test'
@@ -18,7 +18,7 @@ dependencies = [
     'hyperlane_interfaces',
     'hyperlane_message',
     'merkle',
-    'ownership',
+    'ownership path+from-root-7908E40C5BBA5E4E',
     'pause',
     'reentrancy',
     'std',
@@ -48,7 +48,7 @@ name = 'hyperlane_interfaces'
 source = 'member'
 dependencies = [
     'hyperlane_message',
-    'ownership',
+    'ownership path+from-root-7908E40C5BBA5E4E',
     'std',
 ]
 
@@ -65,7 +65,7 @@ name = 'interchain-gas-paymaster'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership',
+    'ownership path+from-root-7908E40C5BBA5E4E',
     'std',
     'std_lib_extended',
 ]
@@ -107,7 +107,7 @@ dependencies = [
     'hyperlane_message',
     'merkle',
     'multisig_ism_metadata',
-    'ownership',
+    'ownership path+from-root-7908E40C5BBA5E4E',
     'std',
     'std_lib_extended',
     'storagemapvec',
@@ -126,9 +126,14 @@ name = 'overhead-igp'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership',
+    'ownership path+from-root-7908E40C5BBA5E4E',
     'std',
 ]
+
+[[package]]
+name = 'ownership'
+source = 'git+https://github.com/fuellabs/sway-libs?rev#5eab914a245600c9fb453b7715b92acb8015417a'
+dependencies = ['std']
 
 [[package]]
 name = 'ownership'
@@ -155,7 +160,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.37.1#83e5479462ed2883591669a42552606ac25f0a04'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.38.0#2d16d70ab9d5ab0de0255941048f811b6d07c6b1'
 dependencies = ['core']
 
 [[package]]
@@ -168,7 +173,7 @@ name = 'storage-gas-oracle'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership',
+    'ownership git+https://github.com/fuellabs/sway-libs?rev#5eab914a245600c9fb453b7715b92acb8015417a',
     'std',
 ]
 

--- a/Forc.lock
+++ b/Forc.lock
@@ -110,7 +110,6 @@ dependencies = [
     'ownership',
     'std',
     'std_lib_extended',
-    'storagemapvec',
 ]
 
 [[package]]
@@ -173,15 +172,9 @@ dependencies = [
 ]
 
 [[package]]
-name = 'storagemapvec'
-source = 'git+https://github.com/fuellabs/sway-libs?tag=v0.9.0#01cb23bfc13be2a95c81dec17933f84991337ac9'
-dependencies = ['std']
-
-[[package]]
 name = 'validator-announce'
 source = 'member'
 dependencies = [
     'std',
     'std_lib_extended',
-    'storagemapvec',
 ]

--- a/Forc.lock
+++ b/Forc.lock
@@ -18,7 +18,7 @@ dependencies = [
     'hyperlane_interfaces',
     'hyperlane_message',
     'merkle',
-    'ownership git+https://github.com/fuellabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'pause',
     'reentrancy',
     'std',
@@ -48,7 +48,7 @@ name = 'hyperlane_interfaces'
 source = 'member'
 dependencies = [
     'hyperlane_message',
-    'ownership git+https://github.com/fuellabs/sway-libs?rev#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'std',
 ]
 
@@ -65,7 +65,7 @@ name = 'interchain-gas-paymaster'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership git+https://github.com/fuellabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'std',
     'std_lib_extended',
 ]
@@ -107,7 +107,7 @@ dependencies = [
     'hyperlane_message',
     'merkle',
     'multisig_ism_metadata',
-    'ownership git+https://github.com/fuellabs/sway-libs?rev#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'std',
     'std_lib_extended',
     'storagemapvec',
@@ -126,18 +126,13 @@ name = 'overhead-igp'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership git+https://github.com/fuellabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'std',
 ]
 
 [[package]]
 name = 'ownership'
-source = 'git+https://github.com/fuellabs/sway-libs?rev#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a'
-dependencies = ['std']
-
-[[package]]
-name = 'ownership'
-source = 'git+https://github.com/fuellabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a'
+source = 'path+from-root-7908E40C5BBA5E4E'
 dependencies = ['std']
 
 [[package]]
@@ -155,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = 'reentrancy'
-source = 'git+https://github.com/FuelLabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a'
+source = 'path+from-root-D26B060B9C691B9B'
 dependencies = ['std']
 
 [[package]]
@@ -173,13 +168,13 @@ name = 'storage-gas-oracle'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership git+https://github.com/fuellabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a',
+    'ownership',
     'std',
 ]
 
 [[package]]
 name = 'storagemapvec'
-source = 'git+https://github.com/FuelLabs/sway-libs?tag=v0.8.0#f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a'
+source = 'path+from-root-BFB7C317AD2BC5A8'
 dependencies = ['std']
 
 [[package]]

--- a/Forc.lock
+++ b/Forc.lock
@@ -18,7 +18,7 @@ dependencies = [
     'hyperlane_interfaces',
     'hyperlane_message',
     'merkle',
-    'ownership path+from-root-7908E40C5BBA5E4E',
+    'ownership',
     'pause',
     'reentrancy',
     'std',
@@ -48,7 +48,7 @@ name = 'hyperlane_interfaces'
 source = 'member'
 dependencies = [
     'hyperlane_message',
-    'ownership path+from-root-7908E40C5BBA5E4E',
+    'ownership',
     'std',
 ]
 
@@ -65,7 +65,7 @@ name = 'interchain-gas-paymaster'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership path+from-root-7908E40C5BBA5E4E',
+    'ownership',
     'std',
     'std_lib_extended',
 ]
@@ -107,7 +107,7 @@ dependencies = [
     'hyperlane_message',
     'merkle',
     'multisig_ism_metadata',
-    'ownership path+from-root-7908E40C5BBA5E4E',
+    'ownership',
     'std',
     'std_lib_extended',
     'storagemapvec',
@@ -126,18 +126,13 @@ name = 'overhead-igp'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership path+from-root-7908E40C5BBA5E4E',
+    'ownership',
     'std',
 ]
 
 [[package]]
 name = 'ownership'
-source = 'git+https://github.com/fuellabs/sway-libs?rev#5eab914a245600c9fb453b7715b92acb8015417a'
-dependencies = ['std']
-
-[[package]]
-name = 'ownership'
-source = 'path+from-root-7908E40C5BBA5E4E'
+source = 'git+https://github.com/fuellabs/sway-libs?tag=v0.9.0#01cb23bfc13be2a95c81dec17933f84991337ac9'
 dependencies = ['std']
 
 [[package]]
@@ -155,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = 'reentrancy'
-source = 'path+from-root-D26B060B9C691B9B'
+source = 'git+https://github.com/fuellabs/sway-libs?tag=v0.9.0#01cb23bfc13be2a95c81dec17933f84991337ac9'
 dependencies = ['std']
 
 [[package]]
@@ -173,13 +168,13 @@ name = 'storage-gas-oracle'
 source = 'member'
 dependencies = [
     'hyperlane_interfaces',
-    'ownership git+https://github.com/fuellabs/sway-libs?rev#5eab914a245600c9fb453b7715b92acb8015417a',
+    'ownership',
     'std',
 ]
 
 [[package]]
 name = 'storagemapvec'
-source = 'path+from-root-BFB7C317AD2BC5A8'
+source = 'git+https://github.com/fuellabs/sway-libs?tag=v0.9.0#01cb23bfc13be2a95c81dec17933f84991337ac9'
 dependencies = ['std']
 
 [[package]]

--- a/Forc.toml
+++ b/Forc.toml
@@ -23,4 +23,5 @@ members = [
 ]
 
 [dependencies]
-ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/ownership" }

--- a/Forc.toml
+++ b/Forc.toml
@@ -23,5 +23,5 @@ members = [
 ]
 
 [dependencies]
-# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/ownership" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }

--- a/Forc.toml
+++ b/Forc.toml
@@ -23,5 +23,4 @@ members = [
 ]
 
 [dependencies]
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/hyperlane-interfaces/Forc.toml
+++ b/contracts/hyperlane-interfaces/Forc.toml
@@ -6,5 +6,4 @@ name = "hyperlane_interfaces"
 
 [dependencies]
 hyperlane_message = { path = "../hyperlane-message" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/hyperlane-interfaces/Forc.toml
+++ b/contracts/hyperlane-interfaces/Forc.toml
@@ -6,4 +6,5 @@ name = "hyperlane_interfaces"
 
 [dependencies]
 hyperlane_message = { path = "../hyperlane-message" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }

--- a/contracts/hyperlane-interfaces/Forc.toml
+++ b/contracts/hyperlane-interfaces/Forc.toml
@@ -7,4 +7,4 @@ name = "hyperlane_interfaces"
 [dependencies]
 hyperlane_message = { path = "../hyperlane-message" }
 # ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }

--- a/contracts/hyperlane-ism-test/src/main.sw
+++ b/contracts/hyperlane-ism-test/src/main.sw
@@ -16,7 +16,7 @@ abi TestISM {
 impl TestISM for Contract {
     #[storage(write)]
     fn set_accept(accept: bool) {
-        storage.accept = accept;
+        storage.accept.write(accept);
     }
 }
 
@@ -24,9 +24,9 @@ impl InterchainSecurityModule for Contract {
     #[storage(read, write)]
     fn verify(metadata: Bytes, message: Bytes) -> bool {
         // To ignore a compiler warning that no storage writes are made.
-        storage.accept = storage.accept;
+        storage.accept.write(storage.accept.read());
 
-        return storage.accept;
+        return storage.accept.read();
     }
 
     #[storage(read)]

--- a/contracts/hyperlane-mailbox/Forc.toml
+++ b/contracts/hyperlane-mailbox/Forc.toml
@@ -8,9 +8,9 @@ name = "hyperlane-mailbox"
 hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
 pause = { path = "../pause" }
-# reentrancy = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
-reentrancy = { path = "/Users/trevor/.forc/git/checkouts/reentrancy-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/reentrancy" }
+# reentrancy = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
+reentrancy = { path = "/Users/trevor/.forc/git/checkouts/reentrancy-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/reentrancy" }
 std_lib_extended = { path = "../std-lib-extended" }

--- a/contracts/hyperlane-mailbox/Forc.toml
+++ b/contracts/hyperlane-mailbox/Forc.toml
@@ -8,9 +8,7 @@ name = "hyperlane-mailbox"
 hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }
 pause = { path = "../pause" }
-# reentrancy = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
-reentrancy = { path = "/Users/trevor/.forc/git/checkouts/reentrancy-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/reentrancy" }
+reentrancy = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }
 std_lib_extended = { path = "../std-lib-extended" }

--- a/contracts/hyperlane-mailbox/Forc.toml
+++ b/contracts/hyperlane-mailbox/Forc.toml
@@ -8,7 +8,9 @@ name = "hyperlane-mailbox"
 hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
 pause = { path = "../pause" }
-reentrancy = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+# reentrancy = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+reentrancy = { path = "/Users/trevor/.forc/git/checkouts/reentrancy-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/reentrancy" }
 std_lib_extended = { path = "../std-lib-extended" }

--- a/contracts/hyperlane-mailbox/src/main.sw
+++ b/contracts/hyperlane-mailbox/src/main.sw
@@ -5,7 +5,7 @@ use std::{auth::msg_sender, bytes::Bytes, call_frames::contract_id, logging::log
 use std_lib_extended::bytes::*;
 
 use merkle::*;
-use ownership::{data_structures::State, *};
+use ownership::{*, data_structures::State};
 use pause::{interface::Pausable, is_paused, pause, require_unpaused, unpause};
 use reentrancy::reentrancy_guard;
 

--- a/contracts/hyperlane-mailbox/tests/harness.rs
+++ b/contracts/hyperlane-mailbox/tests/harness.rs
@@ -64,9 +64,12 @@ async fn get_contract_instance() -> (Mailbox<WalletUnlocked>, Bech32ContractId, 
 
     let mailbox_id = Contract::load_from(
         "./out/debug/hyperlane-mailbox.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/hyperlane-mailbox-storage_slots.json",
-        ).unwrap()).set_configurables(mailbox_configurables),
+        LoadConfiguration::default()
+            .set_storage_configuration(
+                StorageConfiguration::load_from("./out/debug/hyperlane-mailbox-storage_slots.json")
+                    .unwrap(),
+            )
+            .set_configurables(mailbox_configurables),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())
@@ -86,9 +89,12 @@ async fn get_contract_instance() -> (Mailbox<WalletUnlocked>, Bech32ContractId, 
 
     let ism_id = Contract::load_from(
         "../hyperlane-ism-test/out/debug/hyperlane-ism-test.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "../hyperlane-ism-test/out/debug/hyperlane-ism-test-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from(
+                "../hyperlane-ism-test/out/debug/hyperlane-ism-test-storage_slots.json",
+            )
+            .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())
@@ -341,7 +347,9 @@ async fn test_process_id() {
         .unwrap();
 
     // Also make sure the ProcessEvent was logged
-    let events = process_call.decode_logs_with_type::<ProcessEvent>().unwrap();
+    let events = process_call
+        .decode_logs_with_type::<ProcessEvent>()
+        .unwrap();
     assert_eq!(
         events,
         vec![ProcessEvent {

--- a/contracts/hyperlane-mailbox/tests/harness.rs
+++ b/contracts/hyperlane-mailbox/tests/harness.rs
@@ -62,16 +62,14 @@ async fn get_contract_instance() -> (Mailbox<WalletUnlocked>, Bech32ContractId, 
     let mailbox_configurables =
         mailbox_contract::MailboxConfigurables::new().set_LOCAL_DOMAIN(TEST_LOCAL_DOMAIN);
 
-    let mailbox_id = Contract::deploy(
+    let mailbox_id = Contract::load_from(
         "./out/debug/hyperlane-mailbox.bin",
-        &wallet,
-        DeployConfiguration::default()
-            .set_storage_configuration(StorageConfiguration::new(
-                "./out/debug/hyperlane-mailbox-storage_slots.json".to_string(),
-                vec![],
-            ))
-            .set_configurables(mailbox_configurables),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/hyperlane-mailbox-storage_slots.json",
+        ).unwrap()).set_configurables(mailbox_configurables),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
@@ -86,26 +84,25 @@ async fn get_contract_instance() -> (Mailbox<WalletUnlocked>, Bech32ContractId, 
         .await
         .unwrap();
 
-    let ism_id = Contract::deploy(
+    let ism_id = Contract::load_from(
         "../hyperlane-ism-test/out/debug/hyperlane-ism-test.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "../hyperlane-ism-test/out/debug/hyperlane-ism-test-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "../hyperlane-ism-test/out/debug/hyperlane-ism-test-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
-    let msg_recipient_id = Contract::deploy(
+    let msg_recipient_id = Contract::load_from(
         "../hyperlane-msg-recipient-test/out/debug/hyperlane-msg-recipient-test.bin",
-        &wallet,
-        DeployConfiguration::default()
-        .set_storage_configuration(
-        StorageConfiguration::new(
-            "../hyperlane-msg-recipient-test/out/debug/hyperlane-msg-recipient-test-storage_slots.json".to_string(),
-            vec![])),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "../hyperlane-msg-recipient-test/out/debug/hyperlane-msg-recipient-test-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
@@ -209,7 +206,7 @@ async fn test_dispatch_logs_message() {
 
     // Also make sure the DispatchIdEvent was logged
     let events = dispatch_call
-        .get_logs_with_type::<DispatchIdEvent>()
+        .decode_logs_with_type::<DispatchIdEvent>()
         .unwrap();
     assert_eq!(
         events,
@@ -344,7 +341,7 @@ async fn test_process_id() {
         .unwrap();
 
     // Also make sure the ProcessEvent was logged
-    let events = process_call.get_logs_with_type::<ProcessEvent>().unwrap();
+    let events = process_call.decode_logs_with_type::<ProcessEvent>().unwrap();
     assert_eq!(
         events,
         vec![ProcessEvent {
@@ -582,7 +579,7 @@ async fn test_set_default_ism() {
         .unwrap();
     // Ensure the event was logged
     assert_eq!(
-        call.get_logs_with_type::<DefaultIsmSetEvent>().unwrap(),
+        call.decode_logs_with_type::<DefaultIsmSetEvent>().unwrap(),
         vec![DefaultIsmSetEvent {
             module: new_default_ism,
         }]

--- a/contracts/hyperlane-message-test/tests/harness.rs
+++ b/contracts/hyperlane-message-test/tests/harness.rs
@@ -30,9 +30,12 @@ async fn get_contract_instance() -> (TestMessage<WalletUnlocked>, ContractId) {
 
     let id = Contract::load_from(
         "./out/debug/hyperlane-message-test.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/hyperlane-message-test-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from(
+                "./out/debug/hyperlane-message-test-storage_slots.json",
+            )
+            .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/hyperlane-message-test/tests/harness.rs
+++ b/contracts/hyperlane-message-test/tests/harness.rs
@@ -28,14 +28,14 @@ async fn get_contract_instance() -> (TestMessage<WalletUnlocked>, ContractId) {
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/hyperlane-message-test.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/hyperlane-message-test-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/hyperlane-message-test-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 

--- a/contracts/hyperlane-msg-recipient-test/src/main.sw
+++ b/contracts/hyperlane-msg-recipient-test/src/main.sw
@@ -28,22 +28,19 @@ storage {
 impl MessageRecipient for Contract {
     #[storage(read, write)]
     fn handle(origin: u32, sender: b256, message_body: Bytes) {
-        // To ignore a compiler warning that no storage reads are made.
-        let _ = storage.module;
-
-        storage.handled = true;
+        storage.handled.write(true);
     }
 
     #[storage(read)]
     fn interchain_security_module() -> ContractId {
-        storage.module
+        storage.module.read()
     }
 }
 
 impl TestMessageRecipient for Contract {
     #[storage(read)]
     fn handled() -> bool {
-        storage.handled
+        storage.handled.read()
     }
 
     fn dispatch(

--- a/contracts/igp/interchain-gas-paymaster/Forc.toml
+++ b/contracts/igp/interchain-gas-paymaster/Forc.toml
@@ -6,5 +6,6 @@ name = "interchain-gas-paymaster"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
 std_lib_extended = { path = "../../std-lib-extended" }

--- a/contracts/igp/interchain-gas-paymaster/Forc.toml
+++ b/contracts/igp/interchain-gas-paymaster/Forc.toml
@@ -6,6 +6,6 @@ name = "interchain-gas-paymaster"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
 std_lib_extended = { path = "../../std-lib-extended" }

--- a/contracts/igp/interchain-gas-paymaster/Forc.toml
+++ b/contracts/igp/interchain-gas-paymaster/Forc.toml
@@ -6,6 +6,5 @@ name = "interchain-gas-paymaster"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }
 std_lib_extended = { path = "../../std-lib-extended" }

--- a/contracts/igp/interchain-gas-paymaster/src/main.sw
+++ b/contracts/igp/interchain-gas-paymaster/src/main.sw
@@ -17,7 +17,7 @@ use std::{
 
 use std_lib_extended::{option::*, result::*, u256::*};
 
-use ownership::{data_structures::State, *};
+use ownership::{*, data_structures::State};
 
 use hyperlane_interfaces::{
     igp::{

--- a/contracts/igp/interchain-gas-paymaster/tests/harness.rs
+++ b/contracts/igp/interchain-gas-paymaster/tests/harness.rs
@@ -113,16 +113,18 @@ async fn get_contract_instances() -> (
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let igp_id = Contract::deploy(
+    let igp_id = Contract::load_from(
         "./out/debug/interchain-gas-paymaster.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/interchain-gas-paymaster-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/interchain-gas-paymaster-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
+
+
     let igp = InterchainGasPaymaster::new(igp_id, wallet.clone());
 
     let owner_identity = Identity::Address(wallet.address().into());
@@ -133,14 +135,14 @@ async fn get_contract_instances() -> (
         .await
         .unwrap();
 
-    let storage_gas_oracle_id = Contract::deploy(
+    let storage_gas_oracle_id = Contract::load_from(
         "../storage-gas-oracle/out/debug/storage-gas-oracle.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "../storage-gas-oracle/out/debug/storage-gas-oracle-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "../storage-gas-oracle/out/debug/storage-gas-oracle-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
     let storage_gas_oracle = StorageGasOracle::new(storage_gas_oracle_id.clone(), wallet);
@@ -281,7 +283,7 @@ async fn test_pay_for_gas() {
     );
 
     // And that the transaction logged the GasPaymentEvent
-    let events = call.get_logs_with_type::<GasPaymentEvent>().unwrap();
+    let events = call.decode_logs_with_type::<GasPaymentEvent>().unwrap();
     assert_eq!(
         events,
         vec![GasPaymentEvent {
@@ -584,7 +586,7 @@ async fn test_set_gas_oracle() {
         .call()
         .await
         .unwrap();
-    let events = call.get_logs_with_type::<GasOracleSetEvent>().unwrap();
+    let events = call.decode_logs_with_type::<GasOracleSetEvent>().unwrap();
     assert_eq!(
         events,
         vec![GasOracleSetEvent {
@@ -642,7 +644,7 @@ async fn test_set_beneficiary() {
         .await
         .unwrap();
 
-    let events = call.get_logs_with_type::<BeneficiarySetEvent>().unwrap();
+    let events = call.decode_logs_with_type::<BeneficiarySetEvent>().unwrap();
     assert_eq!(
         events,
         vec![BeneficiarySetEvent {
@@ -716,7 +718,7 @@ async fn test_claim() {
         .await
         .unwrap();
 
-    let events = call.get_logs_with_type::<ClaimEvent>().unwrap();
+    let events = call.decode_logs_with_type::<ClaimEvent>().unwrap();
     assert_eq!(
         events,
         vec![ClaimEvent {

--- a/contracts/igp/interchain-gas-paymaster/tests/harness.rs
+++ b/contracts/igp/interchain-gas-paymaster/tests/harness.rs
@@ -115,15 +115,17 @@ async fn get_contract_instances() -> (
 
     let igp_id = Contract::load_from(
         "./out/debug/interchain-gas-paymaster.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/interchain-gas-paymaster-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from(
+                "./out/debug/interchain-gas-paymaster-storage_slots.json",
+            )
+            .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
-
 
     let igp = InterchainGasPaymaster::new(igp_id, wallet.clone());
 
@@ -137,9 +139,12 @@ async fn get_contract_instances() -> (
 
     let storage_gas_oracle_id = Contract::load_from(
         "../storage-gas-oracle/out/debug/storage-gas-oracle.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "../storage-gas-oracle/out/debug/storage-gas-oracle-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from(
+                "../storage-gas-oracle/out/debug/storage-gas-oracle-storage_slots.json",
+            )
+            .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/igp/overhead-igp/Forc.toml
+++ b/contracts/igp/overhead-igp/Forc.toml
@@ -6,5 +6,4 @@ name = "overhead-igp"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/igp/overhead-igp/Forc.toml
+++ b/contracts/igp/overhead-igp/Forc.toml
@@ -6,5 +6,5 @@ name = "overhead-igp"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }

--- a/contracts/igp/overhead-igp/Forc.toml
+++ b/contracts/igp/overhead-igp/Forc.toml
@@ -6,4 +6,5 @@ name = "overhead-igp"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }

--- a/contracts/igp/overhead-igp/src/main.sw
+++ b/contracts/igp/overhead-igp/src/main.sw
@@ -6,7 +6,7 @@ use std::{call_frames::msg_asset_id, constants::ZERO_B256, context::msg_amount};
 
 use hyperlane_interfaces::{igp::InterchainGasPaymaster, ownable::Ownable};
 
-use ownership::{data_structures::State, *};
+use ownership::{*, data_structures::State};
 
 use interface::{DestinationGasOverheadSetEvent, GasOverheadConfig, OverheadIgp};
 

--- a/contracts/igp/overhead-igp/tests/harness.rs
+++ b/contracts/igp/overhead-igp/tests/harness.rs
@@ -66,9 +66,12 @@ async fn get_contract_instances() -> (
         OverheadIgpConfigurables::default().set_INNER_IGP_ID(Bits256(test_igp_id.hash().into()));
     let overhead_igp_id = Contract::load_from(
         "./out/debug/overhead-igp.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/overhead-igp-storage_slots.json",
-        ).unwrap()).set_configurables(overhead_igp_configurables),
+        LoadConfiguration::default()
+            .set_storage_configuration(
+                StorageConfiguration::load_from("./out/debug/overhead-igp-storage_slots.json")
+                    .unwrap(),
+            )
+            .set_configurables(overhead_igp_configurables),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/igp/storage-gas-oracle/Forc.toml
+++ b/contracts/igp/storage-gas-oracle/Forc.toml
@@ -6,4 +6,5 @@ name = "storage-gas-oracle"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }

--- a/contracts/igp/storage-gas-oracle/Forc.toml
+++ b/contracts/igp/storage-gas-oracle/Forc.toml
@@ -6,5 +6,5 @@ name = "storage-gas-oracle"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+# ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }

--- a/contracts/igp/storage-gas-oracle/Forc.toml
+++ b/contracts/igp/storage-gas-oracle/Forc.toml
@@ -6,5 +6,4 @@ name = "storage-gas-oracle"
 
 [dependencies]
 hyperlane_interfaces = { path = "../../hyperlane-interfaces" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-# ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/igp/storage-gas-oracle/tests/harness.rs
+++ b/contracts/igp/storage-gas-oracle/tests/harness.rs
@@ -36,14 +36,14 @@ async fn get_contract_instance() -> (StorageGasOracle<WalletUnlocked>, ContractI
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/storage-gas-oracle.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/storage-gas-oracle-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/storage-gas-oracle-storage_slots.json"
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
@@ -96,7 +96,7 @@ async fn test_set_remote_gas_data_configs_and_get_remote_gas_data() {
         .unwrap();
 
     // Events all correctly logged
-    let events = call.get_logs_with_type::<RemoteGasDataSetEvent>().unwrap();
+    let events = call.decode_logs_with_type::<RemoteGasDataSetEvent>().unwrap();
     assert_eq!(
         events,
         configs

--- a/contracts/igp/storage-gas-oracle/tests/harness.rs
+++ b/contracts/igp/storage-gas-oracle/tests/harness.rs
@@ -38,9 +38,10 @@ async fn get_contract_instance() -> (StorageGasOracle<WalletUnlocked>, ContractI
 
     let id = Contract::load_from(
         "./out/debug/storage-gas-oracle.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/storage-gas-oracle-storage_slots.json"
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from("./out/debug/storage-gas-oracle-storage_slots.json")
+                .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())
@@ -96,7 +97,9 @@ async fn test_set_remote_gas_data_configs_and_get_remote_gas_data() {
         .unwrap();
 
     // Events all correctly logged
-    let events = call.decode_logs_with_type::<RemoteGasDataSetEvent>().unwrap();
+    let events = call
+        .decode_logs_with_type::<RemoteGasDataSetEvent>()
+        .unwrap();
     assert_eq!(
         events,
         configs

--- a/contracts/merkle-test/src/main.sw
+++ b/contracts/merkle-test/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use merkle::StorageMerkleTree;
+use merkle::*;
 
 // A contract to test the StorageMerkleTree.
 abi TestStorageMerkleTree {

--- a/contracts/merkle-test/tests/harness.rs
+++ b/contracts/merkle-test/tests/harness.rs
@@ -26,9 +26,9 @@ async fn get_contract_instance() -> (TestStorageMerkleTree<WalletUnlocked>, Cont
 
     let id = Contract::load_from(
         "./out/debug/merkle-test.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/merkle-test-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from("./out/debug/merkle-test-storage_slots.json").unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/merkle-test/tests/harness.rs
+++ b/contracts/merkle-test/tests/harness.rs
@@ -24,14 +24,14 @@ async fn get_contract_instance() -> (TestStorageMerkleTree<WalletUnlocked>, Cont
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/merkle-test.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/merkle-test-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/merkle-test-storage_slots.json",
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 

--- a/contracts/merkle/src/main.sw
+++ b/contracts/merkle/src/main.sw
@@ -1,6 +1,16 @@
 library;
 
-use std::{constants::ZERO_B256, hash::{keccak256, sha256}, storage::{storage_api::*, storage_key::*}};
+use std::{
+    constants::ZERO_B256,
+    hash::{
+        keccak256,
+        sha256,
+    },
+    storage::{
+        storage_api::*,
+        storage_key::*,
+    },
+};
 
 // The depth of the merkle tree.
 // Forc has a bug that thinks this is unused when it's only used
@@ -153,7 +163,6 @@ impl StorageKey<StorageMerkleTree> {
 
         current
     }
-
 }
 
 impl StorageMerkleTree {

--- a/contracts/multisig-ism-metadata-test/tests/harness.rs
+++ b/contracts/multisig-ism-metadata-test/tests/harness.rs
@@ -33,9 +33,12 @@ async fn get_contract_instance() -> (TestMultisigIsmMetadata<WalletUnlocked>, Co
 
     let id = Contract::load_from(
         "./out/debug/multisig-ism-metadata-test.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/multisig-ism-metadata-test-storage_slots.json"
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from(
+                "./out/debug/multisig-ism-metadata-test-storage_slots.json",
+            )
+            .unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/multisig-ism-metadata-test/tests/harness.rs
+++ b/contracts/multisig-ism-metadata-test/tests/harness.rs
@@ -31,14 +31,14 @@ async fn get_contract_instance() -> (TestMultisigIsmMetadata<WalletUnlocked>, Co
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/multisig-ism-metadata-test.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/multisig-ism-metadata-test-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/multisig-ism-metadata-test-storage_slots.json"
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 

--- a/contracts/multisig-ism-metadata/src/main.sw
+++ b/contracts/multisig-ism-metadata/src/main.sw
@@ -1,7 +1,8 @@
 library;
 
 use std::{
-    b512::B512,
+    b
+512::B512,
     bytes::Bytes,
     constants::ZERO_B256,
     hash::keccak256,

--- a/contracts/multisig-ism-metadata/src/main.sw
+++ b/contracts/multisig-ism-metadata/src/main.sw
@@ -1,8 +1,7 @@
 library;
 
 use std::{
-    b
-512::B512,
+    b512::B512,
     bytes::Bytes,
     constants::ZERO_B256,
     hash::keccak256,

--- a/contracts/multisig-ism/Forc.toml
+++ b/contracts/multisig-ism/Forc.toml
@@ -11,4 +11,3 @@ merkle = { path = "../merkle" }
 multisig_ism_metadata = { path = "../multisig-ism-metadata" }
 ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }
 std_lib_extended = { path = "../std-lib-extended" }
-storagemapvec = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/multisig-ism/Forc.toml
+++ b/contracts/multisig-ism/Forc.toml
@@ -9,6 +9,8 @@ hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
 multisig_ism_metadata = { path = "../multisig-ism-metadata" }
-ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
 std_lib_extended = { path = "../std-lib-extended" }
-storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/storagemapvec" }

--- a/contracts/multisig-ism/Forc.toml
+++ b/contracts/multisig-ism/Forc.toml
@@ -9,8 +9,6 @@ hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
 multisig_ism_metadata = { path = "../multisig-ism-metadata" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
+ownership = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }
 std_lib_extended = { path = "../std-lib-extended" }
-# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
-storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/storagemapvec" }
+storagemapvec = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/multisig-ism/Forc.toml
+++ b/contracts/multisig-ism/Forc.toml
@@ -9,8 +9,8 @@ hyperlane_interfaces = { path = "../hyperlane-interfaces" }
 hyperlane_message = { path = "../hyperlane-message" }
 merkle = { path = "../merkle" }
 multisig_ism_metadata = { path = "../multisig-ism-metadata" }
-# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "v0.8.0" }
-ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/ownership" }
+# ownership = { git = "https://github.com/fuellabs/sway-libs", rev = "5eab914" }
+ownership = { path = "/Users/trevor/.forc/git/checkouts/ownership-f6c4cb75510d36fd/5eab914a245600c9fb453b7715b92acb8015417a/libs/ownership" }
 std_lib_extended = { path = "../std-lib-extended" }
-# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
-storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/storagemapvec" }
+# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
+storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/storagemapvec" }

--- a/contracts/multisig-ism/src/main.sw
+++ b/contracts/multisig-ism/src/main.sw
@@ -26,7 +26,7 @@ use interface::MultisigIsm;
 
 use hyperlane_interfaces::{InterchainSecurityModule, ModuleType, ownable::Ownable};
 
-use ownership::{data_structures::State, *};
+use ownership::{*, data_structures::State};
 
 use multisig_ism_metadata::MultisigMetadata;
 

--- a/contracts/multisig-ism/src/main.sw
+++ b/contracts/multisig-ism/src/main.sw
@@ -16,8 +16,6 @@ use std::{
     },
 };
 
-use storagemapvec::StorageMapVec;
-
 use hyperlane_message::{EncodedMessage, Message};
 
 use merkle::StorageMerkleTree;

--- a/contracts/multisig-ism/tests/harness.rs
+++ b/contracts/multisig-ism/tests/harness.rs
@@ -59,9 +59,9 @@ async fn get_contract_instance() -> (MultisigIsm<WalletUnlocked>, ContractId, Wa
 
     let id = Contract::load_from(
         "./out/debug/multisig_ism.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/multisig_ism-storage_slots.json"
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from("./out/debug/multisig_ism-storage_slots.json").unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())
@@ -88,9 +88,14 @@ async fn deploy_mailbox(wallet: WalletUnlocked) -> Mailbox<WalletUnlocked> {
 
     let mailbox_id = Contract::load_from(
         "../hyperlane-mailbox/out/debug/hyperlane-mailbox.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "../hyperlane-mailbox/out/debug/hyperlane-mailbox-storage_slots.json"
-        ).unwrap()).set_configurables(mailbox_configurables),
+        LoadConfiguration::default()
+            .set_storage_configuration(
+                StorageConfiguration::load_from(
+                    "../hyperlane-mailbox/out/debug/hyperlane-mailbox-storage_slots.json",
+                )
+                .unwrap(),
+            )
+            .set_configurables(mailbox_configurables),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/multisig-ism/tests/harness.rs
+++ b/contracts/multisig-ism/tests/harness.rs
@@ -57,14 +57,14 @@ async fn get_contract_instance() -> (MultisigIsm<WalletUnlocked>, ContractId, Wa
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/multisig_ism.bin",
-        &wallet,
-        DeployConfiguration::default().set_storage_configuration(StorageConfiguration::new(
-            "./out/debug/multisig_ism-storage_slots.json".to_string(),
-            vec![],
-        )),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/multisig_ism-storage_slots.json"
+        ).unwrap()),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
@@ -86,16 +86,14 @@ async fn deploy_mailbox(wallet: WalletUnlocked) -> Mailbox<WalletUnlocked> {
     let mailbox_configurables =
         mailbox_contract::MailboxConfigurables::new().set_LOCAL_DOMAIN(TEST_LOCAL_DOMAIN);
 
-    let mailbox_id = Contract::deploy(
+    let mailbox_id = Contract::load_from(
         "../hyperlane-mailbox/out/debug/hyperlane-mailbox.bin",
-        &wallet,
-        DeployConfiguration::default()
-            .set_storage_configuration(StorageConfiguration::new(
-                "../hyperlane-mailbox/out/debug/hyperlane-mailbox-storage_slots.json".to_string(),
-                vec![],
-            ))
-            .set_configurables(mailbox_configurables),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "../hyperlane-mailbox/out/debug/hyperlane-mailbox-storage_slots.json"
+        ).unwrap()).set_configurables(mailbox_configurables),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 

--- a/contracts/pause-test/tests/harness.rs
+++ b/contracts/pause-test/tests/harness.rs
@@ -23,9 +23,9 @@ async fn get_contract_instance() -> (PauseTest<WalletUnlocked>, ContractId) {
 
     let id = Contract::load_from(
         "./out/debug/pause-test.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/pause-test-storage_slots.json",
-        ).unwrap()),
+        LoadConfiguration::default().set_storage_configuration(
+            StorageConfiguration::load_from("./out/debug/pause-test-storage_slots.json").unwrap(),
+        ),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())

--- a/contracts/pause/src/lib.sw
+++ b/contracts/pause/src/lib.sw
@@ -3,7 +3,7 @@ library;
 mod interface;
 mod r#storage;
 
-use std::{logging::log, storage::{get, store}};
+use std::{logging::log, storage::storage_api::{read, write}};
 
 use interface::{PausedEvent, UnpausedEvent};
 use storage::PAUSED_STORAGE_KEY;
@@ -16,7 +16,7 @@ pub fn require_unpaused() {
 /// Returns whether the contract is paused.
 #[storage(read)]
 pub fn is_paused() -> bool {
-    get(PAUSED_STORAGE_KEY).unwrap_or(false)
+    read(PAUSED_STORAGE_KEY, 0).unwrap_or(false)
 }
 
 /// Sets the contract to paused.
@@ -24,7 +24,7 @@ pub fn is_paused() -> bool {
 #[storage(read, write)]
 pub fn pause() {
     require(!is_paused(), "contract is already paused");
-    store(PAUSED_STORAGE_KEY, true);
+    write(PAUSED_STORAGE_KEY, 0, true);
     log(PausedEvent {})
 }
 
@@ -33,6 +33,6 @@ pub fn pause() {
 #[storage(read, write)]
 pub fn unpause() {
     require(is_paused(), "contract is not paused");
-    store(PAUSED_STORAGE_KEY, false);
+    write(PAUSED_STORAGE_KEY, 0, false);
     log(UnpausedEvent {})
 }

--- a/contracts/std-lib-extended/src/auth.sw
+++ b/contracts/std-lib-extended/src/auth.sw
@@ -3,7 +3,7 @@ library;
 use std::auth::msg_sender;
 
 /// Gets the b256 representation of the msg_sender.
-fn msg_sender_b256() -> b256 {
+pub fn msg_sender_b256() -> b256 {
     match msg_sender().unwrap() {
         Identity::Address(address) => address.into(),
         Identity::ContractId(id) => id.into(),

--- a/contracts/std-lib-extended/src/auth.sw
+++ b/contracts/std-lib-extended/src/auth.sw
@@ -1,0 +1,11 @@
+library;
+
+use std::auth::msg_sender;
+
+/// Gets the b256 representation of the msg_sender.
+fn msg_sender_b256() -> b256 {
+    match msg_sender().unwrap() {
+        Identity::Address(address) => address.into(),
+        Identity::ContractId(id) => id.into(),
+    }
+}

--- a/contracts/std-lib-extended/src/bytes.sw
+++ b/contracts/std-lib-extended/src/bytes.sw
@@ -1,6 +1,12 @@
 library;
 
-use std::{b512::B512, bytes::Bytes, constants::ZERO_B256, u256::U256, vm::evm::evm_address::EvmAddress};
+use std::{
+    b512::B512,
+    bytes::Bytes,
+    constants::ZERO_B256,
+    u256::U256,
+    vm::evm::evm_address::EvmAddress,
+};
 use ::mem::CopyTypeWrapper;
 
 /// The number of bytes in a b256.
@@ -126,7 +132,7 @@ impl Bytes {
         offset: u64,
         bytes_ptr: raw_ptr,
         byte_count: u64,
-    ) -> u64 {
+) -> u64 {
         let new_byte_offset = offset + byte_count;
         // Ensure that the written bytes will stay within the correct bounds.
         assert(new_byte_offset <= self.len);
@@ -459,7 +465,7 @@ fn write_and_read_u256(ref mut bytes: Bytes, offset: u64, value: U256) -> U256 {
 fn test_write_and_read_u256() {
     let mut bytes = Bytes::with_length(64);
     let value = U256::from((1, 2, 3, 4));
-    
+
     // 0 byte offset
     assert(value == write_and_read_u256(bytes, 0u64, value));
 

--- a/contracts/std-lib-extended/src/bytes.sw
+++ b/contracts/std-lib-extended/src/bytes.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::{b512::B512, bytes::Bytes, constants::ZERO_B256, vm::evm::evm_address::EvmAddress};
+use std::{b512::B512, bytes::Bytes, constants::ZERO_B256, u256::U256, vm::evm::evm_address::EvmAddress};
 use ::mem::CopyTypeWrapper;
 
 /// The number of bytes in a b256.
@@ -329,6 +329,30 @@ impl Bytes {
         assert(offset == _self.len);
         _self
     }
+
+    // ===== U256 ====
+    /// Writes a U256 at the specified offset. Reverts if it violates the
+    /// bounds of self.
+    /// Returns the byte index after the end of the U256.
+    pub fn write_u256(ref mut self, offset: u64, value: U256) -> u64 {
+        // self.write_packed_bytes(offset, value.packed_bytes(), U64_BYTE_COUNT)
+        let mut offset = self.write_u64(offset, value.d);
+        offset = self.write_u64(offset, value.c);
+        offset = self.write_u64(offset, value.b);
+        offset = self.write_u64(offset, value.a);
+        offset
+    }
+
+    /// Reads a U256 at the specified offset.
+    /// Reverts if it violates the bounds of self.
+    pub fn read_u256(self, offset: u64) -> U256 {
+        U256 {
+            d: self.read_u64(offset),
+            c: self.read_u64(offset + 8),
+            b: self.read_u64(offset + 16),
+            a: self.read_u64(offset + 24),
+        }
+    }
 }
 
 /// Bytes::from_vec_u8 requires a mutable Vec<u8> to be passed in.
@@ -424,6 +448,26 @@ fn test_write_and_read_b512() {
 
     // 50 byte offset - tests non-word-aligned case and overwriting existing bytes
     assert(value == write_and_read_b512(bytes, 50u64, value));
+}
+
+fn write_and_read_u256(ref mut bytes: Bytes, offset: u64, value: U256) -> U256 {
+    let _ = bytes.write_u256(offset, value);
+    bytes.read_u256(offset)
+}
+
+#[test()]
+fn test_write_and_read_u256() {
+    let mut bytes = Bytes::with_length(64);
+    let value = U256::from((1, 2, 3, 4));
+    
+    // 0 byte offset
+    assert(value == write_and_read_u256(bytes, 0u64, value));
+
+    // 32 byte offset - tests word-aligned case and writing to the end of the Bytes
+    assert(value == write_and_read_u256(bytes, 32u64, value));
+
+    // 18 byte offset - tests non-word-aligned case and overwriting existing bytes
+    assert(value == write_and_read_u256(bytes, 18u64, value));
 }
 
 fn write_and_read_u64(ref mut bytes: Bytes, offset: u64, value: u64) -> u64 {
@@ -544,7 +588,6 @@ fn test_write_and_read_str() {
     let mut bytes = Bytes::with_length(64);
 
     let value = "\x19Ethereum Signed Message:\n";
-    let value_len = 30u64;
 
     assert(std::hash::sha256(value) == std::hash::sha256(write_and_read_str(bytes, 0u64, value)));
 }

--- a/contracts/std-lib-extended/src/bytes.sw
+++ b/contracts/std-lib-extended/src/bytes.sw
@@ -336,10 +336,10 @@ impl Bytes {
     /// Returns the byte index after the end of the U256.
     pub fn write_u256(ref mut self, offset: u64, value: U256) -> u64 {
         // self.write_packed_bytes(offset, value.packed_bytes(), U64_BYTE_COUNT)
-        let mut offset = self.write_u64(offset, value.d);
-        offset = self.write_u64(offset, value.c);
+        let mut offset = self.write_u64(offset, value.a);
         offset = self.write_u64(offset, value.b);
-        offset = self.write_u64(offset, value.a);
+        offset = self.write_u64(offset, value.c);
+        offset = self.write_u64(offset, value.d);
         offset
     }
 
@@ -347,10 +347,10 @@ impl Bytes {
     /// Reverts if it violates the bounds of self.
     pub fn read_u256(self, offset: u64) -> U256 {
         U256 {
-            d: self.read_u64(offset),
-            c: self.read_u64(offset + 8),
-            b: self.read_u64(offset + 16),
-            a: self.read_u64(offset + 24),
+            a: self.read_u64(offset),
+            b: self.read_u64(offset + 8),
+            c: self.read_u64(offset + 16),
+            d: self.read_u64(offset + 24),
         }
     }
 }

--- a/contracts/std-lib-extended/src/lib.sw
+++ b/contracts/std-lib-extended/src/lib.sw
@@ -1,5 +1,6 @@
 library;
 
+mod auth;
 mod mem;
 mod bytes;
 mod option;

--- a/contracts/validator-announce/Forc.toml
+++ b/contracts/validator-announce/Forc.toml
@@ -6,4 +6,3 @@ name = "validator-announce"
 
 [dependencies]
 std_lib_extended = { path = "../std-lib-extended" }
-storagemapvec = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/validator-announce/Forc.toml
+++ b/contracts/validator-announce/Forc.toml
@@ -6,5 +6,4 @@ name = "validator-announce"
 
 [dependencies]
 std_lib_extended = { path = "../std-lib-extended" }
-# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
-storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/storagemapvec" }
+storagemapvec = { git = "https://github.com/fuellabs/sway-libs", tag = "v0.9.0" }

--- a/contracts/validator-announce/Forc.toml
+++ b/contracts/validator-announce/Forc.toml
@@ -6,4 +6,5 @@ name = "validator-announce"
 
 [dependencies]
 std_lib_extended = { path = "../std-lib-extended" }
-storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
+storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/storagemapvec" }

--- a/contracts/validator-announce/Forc.toml
+++ b/contracts/validator-announce/Forc.toml
@@ -6,5 +6,5 @@ name = "validator-announce"
 
 [dependencies]
 std_lib_extended = { path = "../std-lib-extended" }
-# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.8.0" }
-storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/f6bb5c234e020d556e1bc688e0f1f368dc9b0f9a/libs/storagemapvec" }
+# storagemapvec = { git = "https://github.com/FuelLabs/sway-libs", rev = "5eab914" }
+storagemapvec = { path = "/Users/trevor/.forc/git/checkouts/storagemapvec-30641758e4be7209/5eab914a245600c9fb453b7715b92acb8015417a/libs/storagemapvec" }

--- a/contracts/validator-announce/src/main.sw
+++ b/contracts/validator-announce/src/main.sw
@@ -15,8 +15,6 @@ use std::{
     },
 };
 
-use storagemapvec::StorageMapVec;
-
 use digest::{get_announcement_digest, get_replay_id};
 use interface::{ValidatorAnnounce, ValidatorAnnouncementEvent};
 use storable_string::{MAX_STORABLE_STRING_CHARS, StorableString};

--- a/contracts/validator-announce/src/main.sw
+++ b/contracts/validator-announce/src/main.sw
@@ -7,8 +7,8 @@ mod interface;
 use std::{
     b512::B512,
     bytes::Bytes,
-    storage::storage_vec::*,
     storage::storage_map::*,
+    storage::storage_vec::*,
     vm::evm::{
         ecr::ec_recover_evm_address,
         evm_address::EvmAddress,
@@ -148,7 +148,8 @@ impl ValidatorAnnounce for Contract {
 /// Idemptotent.
 #[storage(read, write)]
 fn upsert_validator(validator: EvmAddress) {
-    if storage.validators_map.get(validator).try_read().is_none() {
+    if storage.validators_map.get(validator).try_read().is_none()
+    {
         storage.validators_vec.push(validator);
     }
     storage.validators_map.insert(validator, true);

--- a/contracts/validator-announce/tests/harness.rs
+++ b/contracts/validator-announce/tests/harness.rs
@@ -57,16 +57,14 @@ async fn get_contract_instance() -> (ValidatorAnnounce<WalletUnlocked>, Contract
         .set_LOCAL_DOMAIN(TEST_LOCAL_DOMAIN)
         .set_MAILBOX_ID(Bits256::from_hex_str(TEST_MAILBOX_ID).unwrap());
 
-    let id = Contract::deploy(
+    let id = Contract::load_from(
         "./out/debug/validator-announce.bin",
-        &wallet,
-        DeployConfiguration::default()
-            .set_storage_configuration(StorageConfiguration::new(
-                "./out/debug/validator-announce-storage_slots.json".to_string(),
-                vec![],
-            ))
-            .set_configurables(configurables),
+        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
+            "./out/debug/validator-announce-storage_slots.json"
+        ).unwrap()).set_configurables(configurables),
     )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
     .await
     .unwrap();
 
@@ -119,7 +117,7 @@ async fn test_announce() {
         .unwrap();
 
     let events = call
-        .get_logs_with_type::<ValidatorAnnouncementEvent>()
+        .decode_logs_with_type::<ValidatorAnnouncementEvent>()
         .unwrap();
     assert_eq!(
         events,

--- a/contracts/validator-announce/tests/harness.rs
+++ b/contracts/validator-announce/tests/harness.rs
@@ -59,9 +59,14 @@ async fn get_contract_instance() -> (ValidatorAnnounce<WalletUnlocked>, Contract
 
     let id = Contract::load_from(
         "./out/debug/validator-announce.bin",
-        LoadConfiguration::default().set_storage_configuration(StorageConfiguration::load_from(
-            "./out/debug/validator-announce-storage_slots.json"
-        ).unwrap()).set_configurables(configurables),
+        LoadConfiguration::default()
+            .set_storage_configuration(
+                StorageConfiguration::load_from(
+                    "./out/debug/validator-announce-storage_slots.json",
+                )
+                .unwrap(),
+            )
+            .set_configurables(configurables),
     )
     .unwrap()
     .deploy(&wallet, TxParameters::default())


### PR DESCRIPTION
* Replaces https://github.com/hyperlane-xyz/fuel-contracts/pull/86, which includes some quality of life changes for use in warp routes
* Moves to forc 0.38, which requires moving over to their new storage API 🎉 
* Removes storagemapvec
* related: https://github.com/hyperlane-xyz/fuel-contracts/issues/66